### PR TITLE
Implement Top Tracks Feature with Local Caching

### DIFF
--- a/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
@@ -1,0 +1,54 @@
+package com.daniel.spotyinsights.data.di
+
+import android.content.Context
+import androidx.room.Room
+import com.daniel.spotyinsights.data.local.SpotifyDatabase
+import com.daniel.spotyinsights.data.local.dao.TrackDao
+import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.data.repository.TopTracksRepositoryImpl
+import com.daniel.spotyinsights.domain.repository.TopTracksRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataModule {
+
+    @Provides
+    @Singleton
+    fun provideSpotifyDatabase(
+        @ApplicationContext context: Context
+    ): SpotifyDatabase {
+        return Room.databaseBuilder(
+            context,
+            SpotifyDatabase::class.java,
+            SpotifyDatabase.DATABASE_NAME
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideTrackDao(database: SpotifyDatabase): TrackDao {
+        return database.trackDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideSpotifyApiService(retrofit: Retrofit): SpotifyApiService {
+        return retrofit.create(SpotifyApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideTopTracksRepository(
+        spotifyApiService: SpotifyApiService,
+        trackDao: TrackDao
+    ): TopTracksRepository {
+        return TopTracksRepositoryImpl(spotifyApiService, trackDao)
+    }
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/SpotifyDatabase.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/SpotifyDatabase.kt
@@ -1,0 +1,24 @@
+package com.daniel.spotyinsights.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.daniel.spotyinsights.data.local.dao.TrackDao
+import com.daniel.spotyinsights.data.local.entity.*
+
+@Database(
+    entities = [
+        TrackEntity::class,
+        ArtistEntity::class,
+        AlbumEntity::class,
+        TrackArtistCrossRef::class
+    ],
+    version = 1,
+    exportSchema = false
+)
+abstract class SpotifyDatabase : RoomDatabase() {
+    abstract fun trackDao(): TrackDao
+
+    companion object {
+        const val DATABASE_NAME = "spotify_database"
+    }
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/dao/TrackDao.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/dao/TrackDao.kt
@@ -1,0 +1,63 @@
+package com.daniel.spotyinsights.data.local.dao
+
+import androidx.room.*
+import com.daniel.spotyinsights.data.local.entity.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TrackDao {
+    @Transaction
+    @Query("""
+        SELECT * FROM tracks 
+        WHERE fetchTimeMs >= :minFetchTimeMs 
+        ORDER BY popularity DESC
+    """)
+    fun getTopTracks(minFetchTimeMs: Long): Flow<List<TrackWithRelations>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTracks(tracks: List<TrackEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArtists(artists: List<ArtistEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAlbums(albums: List<AlbumEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTrackArtistCrossRefs(crossRefs: List<TrackArtistCrossRef>)
+
+    @Transaction
+    suspend fun insertTracksWithRelations(
+        tracks: List<TrackEntity>,
+        artists: List<ArtistEntity>,
+        albums: List<AlbumEntity>,
+        trackArtistCrossRefs: List<TrackArtistCrossRef>
+    ) {
+        insertTracks(tracks)
+        insertArtists(artists)
+        insertAlbums(albums)
+        insertTrackArtistCrossRefs(trackArtistCrossRefs)
+    }
+
+    @Query("DELETE FROM tracks WHERE fetchTimeMs < :minFetchTimeMs")
+    suspend fun deleteOldTracks(minFetchTimeMs: Long)
+}
+
+data class TrackWithRelations(
+    @Embedded val track: TrackEntity,
+    @Relation(
+        parentColumn = "albumId",
+        entityColumn = "id"
+    )
+    val album: AlbumEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "id",
+        associateBy = Junction(
+            value = TrackArtistCrossRef::class,
+            parentColumn = "trackId",
+            entityColumn = "artistId"
+        )
+    )
+    val artists: List<ArtistEntity>
+) 

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/entity/TrackEntity.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/entity/TrackEntity.kt
@@ -1,0 +1,61 @@
+package com.daniel.spotyinsights.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.ForeignKey
+import androidx.room.Junction
+
+@Entity(tableName = "tracks")
+data class TrackEntity(
+    @PrimaryKey
+    val id: String,
+    val name: String,
+    val durationMs: Long,
+    val popularity: Int,
+    val previewUrl: String?,
+    val spotifyUrl: String,
+    val explicit: Boolean,
+    val albumId: String,
+    val fetchTimeMs: Long // To track when the data was fetched
+)
+
+@Entity(tableName = "artists")
+data class ArtistEntity(
+    @PrimaryKey
+    val id: String,
+    val name: String,
+    val spotifyUrl: String
+)
+
+@Entity(tableName = "albums")
+data class AlbumEntity(
+    @PrimaryKey
+    val id: String,
+    val name: String,
+    val releaseDate: String,
+    val imageUrl: String,
+    val spotifyUrl: String
+)
+
+@Entity(
+    tableName = "track_artist_cross_ref",
+    primaryKeys = ["trackId", "artistId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = TrackEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["trackId"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = ArtistEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["artistId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class TrackArtistCrossRef(
+    val trackId: String,
+    val artistId: String
+) 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/api/SpotifyApiService.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/api/SpotifyApiService.kt
@@ -1,0 +1,14 @@
+package com.daniel.spotyinsights.data.network.api
+
+import com.daniel.spotyinsights.data.network.model.track.SpotifyTrackResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface SpotifyApiService {
+    @GET("v1/me/top/tracks")
+    suspend fun getTopTracks(
+        @Query("time_range") timeRange: String, // short_term (4 weeks) | medium_term (6 months) | long_term (years)
+        @Query("limit") limit: Int = 50,
+        @Query("offset") offset: Int = 0
+    ): SpotifyTrackResponse
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/model/track/SpotifyTrackResponse.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/model/track/SpotifyTrackResponse.kt
@@ -1,0 +1,72 @@
+package com.daniel.spotyinsights.data.network.model.track
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SpotifyTrackResponse(
+    @Json(name = "items")
+    val items: List<SpotifyTrack>,
+    @Json(name = "total")
+    val total: Int,
+    @Json(name = "limit")
+    val limit: Int,
+    @Json(name = "offset")
+    val offset: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyTrack(
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "name")
+    val name: String,
+    @Json(name = "duration_ms")
+    val durationMs: Long,
+    @Json(name = "popularity")
+    val popularity: Int,
+    @Json(name = "preview_url")
+    val previewUrl: String?,
+    @Json(name = "external_urls")
+    val externalUrls: Map<String, String>,
+    @Json(name = "explicit")
+    val explicit: Boolean,
+    @Json(name = "album")
+    val album: SpotifyAlbum,
+    @Json(name = "artists")
+    val artists: List<SpotifyArtist>
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyAlbum(
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "name")
+    val name: String,
+    @Json(name = "release_date")
+    val releaseDate: String,
+    @Json(name = "images")
+    val images: List<SpotifyImage>,
+    @Json(name = "external_urls")
+    val externalUrls: Map<String, String>
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyArtist(
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "name")
+    val name: String,
+    @Json(name = "external_urls")
+    val externalUrls: Map<String, String>
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyImage(
+    @Json(name = "url")
+    val url: String,
+    @Json(name = "height")
+    val height: Int?,
+    @Json(name = "width")
+    val width: Int?
+) 

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/TopTracksRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/TopTracksRepositoryImpl.kt
@@ -1,0 +1,129 @@
+package com.daniel.spotyinsights.data.repository
+
+import com.daniel.spotyinsights.data.local.dao.TrackDao
+import com.daniel.spotyinsights.data.local.entity.*
+import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.data.network.model.track.SpotifyTrack
+import com.daniel.spotyinsights.domain.model.*
+import com.daniel.spotyinsights.domain.repository.TimeRange
+import com.daniel.spotyinsights.domain.repository.TopTracksRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TopTracksRepositoryImpl @Inject constructor(
+    private val spotifyApiService: SpotifyApiService,
+    private val trackDao: TrackDao
+) : TopTracksRepository {
+
+    override fun getTopTracks(timeRange: TimeRange): Flow<Result<List<Track>>> {
+        val minFetchTimeMs = System.currentTimeMillis() - CACHE_DURATION_MS
+        return trackDao.getTopTracks(minFetchTimeMs)
+            .map { tracks ->
+                Result.Success(tracks.map { it.toDomainModel() })
+            }
+    }
+
+    override suspend fun refreshTopTracks(timeRange: TimeRange): Result<Unit> {
+        return try {
+            val response = spotifyApiService.getTopTracks(
+                timeRange = timeRange.toApiValue(),
+                limit = 50
+            )
+
+            val currentTimeMs = System.currentTimeMillis()
+            val tracks = mutableListOf<TrackEntity>()
+            val artists = mutableListOf<ArtistEntity>()
+            val albums = mutableListOf<AlbumEntity>()
+            val trackArtistRefs = mutableListOf<TrackArtistCrossRef>()
+
+            response.items.forEach { spotifyTrack ->
+                tracks.add(spotifyTrack.toTrackEntity(currentTimeMs))
+                artists.addAll(spotifyTrack.artists.map { it.toArtistEntity() })
+                albums.add(spotifyTrack.album.toAlbumEntity())
+                trackArtistRefs.addAll(
+                    spotifyTrack.artists.map { artist ->
+                        TrackArtistCrossRef(spotifyTrack.id, artist.id)
+                    }
+                )
+            }
+
+            trackDao.insertTracksWithRelations(
+                tracks = tracks,
+                artists = artists.distinctBy { it.id },
+                albums = albums.distinctBy { it.id },
+                trackArtistCrossRefs = trackArtistRefs
+            )
+
+            // Clean up old data
+            trackDao.deleteOldTracks(currentTimeMs - CACHE_DURATION_MS)
+
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+
+    private fun TimeRange.toApiValue(): String = when (this) {
+        TimeRange.SHORT_TERM -> "short_term"
+        TimeRange.MEDIUM_TERM -> "medium_term"
+        TimeRange.LONG_TERM -> "long_term"
+    }
+
+    private fun TrackWithRelations.toDomainModel() = Track(
+        id = track.id,
+        name = track.name,
+        artists = artists.map { artist ->
+            Artist(
+                id = artist.id,
+                name = artist.name,
+                spotifyUrl = artist.spotifyUrl
+            )
+        },
+        album = Album(
+            id = album.id,
+            name = album.name,
+            releaseDate = album.releaseDate,
+            imageUrl = album.imageUrl,
+            spotifyUrl = album.spotifyUrl
+        ),
+        durationMs = track.durationMs,
+        popularity = track.popularity,
+        previewUrl = track.previewUrl,
+        spotifyUrl = track.spotifyUrl,
+        explicit = track.explicit
+    )
+
+    private fun SpotifyTrack.toTrackEntity(fetchTimeMs: Long) = TrackEntity(
+        id = id,
+        name = name,
+        durationMs = durationMs,
+        popularity = popularity,
+        previewUrl = previewUrl,
+        spotifyUrl = externalUrls["spotify"] ?: "",
+        explicit = explicit,
+        albumId = album.id,
+        fetchTimeMs = fetchTimeMs
+    )
+
+    private fun SpotifyArtist.toArtistEntity() = ArtistEntity(
+        id = id,
+        name = name,
+        spotifyUrl = externalUrls["spotify"] ?: ""
+    )
+
+    private fun SpotifyAlbum.toAlbumEntity() = AlbumEntity(
+        id = id,
+        name = name,
+        releaseDate = releaseDate,
+        imageUrl = images.firstOrNull()?.url ?: "",
+        spotifyUrl = externalUrls["spotify"] ?: ""
+    )
+
+    companion object {
+        private val CACHE_DURATION_MS = TimeUnit.HOURS.toMillis(24) // Cache for 24 hours
+    }
+} 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/model/Track.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/model/Track.kt
@@ -1,0 +1,27 @@
+package com.daniel.spotyinsights.domain.model
+
+data class Track(
+    val id: String,
+    val name: String,
+    val artists: List<Artist>,
+    val album: Album,
+    val durationMs: Long,
+    val popularity: Int,
+    val previewUrl: String?,
+    val spotifyUrl: String,
+    val explicit: Boolean
+)
+
+data class Artist(
+    val id: String,
+    val name: String,
+    val spotifyUrl: String
+)
+
+data class Album(
+    val id: String,
+    val name: String,
+    val releaseDate: String,
+    val imageUrl: String,
+    val spotifyUrl: String
+) 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/repository/TopTracksRepository.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/repository/TopTracksRepository.kt
@@ -1,0 +1,17 @@
+package com.daniel.spotyinsights.domain.repository
+
+import com.daniel.spotyinsights.domain.model.Result
+import com.daniel.spotyinsights.domain.model.Track
+import kotlinx.coroutines.flow.Flow
+
+enum class TimeRange {
+    SHORT_TERM, // 4 weeks
+    MEDIUM_TERM, // 6 months
+    LONG_TERM // years
+}
+
+interface TopTracksRepository {
+    fun getTopTracks(timeRange: TimeRange): Flow<Result<List<Track>>>
+    
+    suspend fun refreshTopTracks(timeRange: TimeRange): Result<Unit>
+} 


### PR DESCRIPTION
This PR implements the top tracks feature with local caching support.

## Key Changes
1. Domain Layer:
   - Added Track, Artist, Album domain models
   - Created TopTracksRepository interface with TimeRange support

2. Data Layer:
   - Room database setup with entities and relationships
   - Spotify API models and service implementation
   - Repository implementation with 24h caching strategy
   - Dependency injection configuration

## Implementation Details
- Efficient caching with 24-hour expiration
- Automatic cleanup of old data
- Error handling with Result type
- Clean architecture separation
- Type-safe data mapping

## Testing Checklist
- [ ] Cache invalidation
- [ ] Network error handling
- [ ] Data mapping accuracy
- [ ] Memory usage with large datasets

## Next Steps
1. Add pagination support
2. Implement offline mode
3. Add track statistics
4. Optimize database queries