### PR TITLE
feat: Add top artists and recommendations features

### DIFF
--- a/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
@@ -3,9 +3,14 @@ package com.daniel.spotyinsights.data.di
 import android.content.Context
 import androidx.room.Room
 import com.daniel.spotyinsights.data.local.SpotifyDatabase
+import com.daniel.spotyinsights.data.local.dao.ArtistDao
 import com.daniel.spotyinsights.data.local.dao.TrackDao
 import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.data.repository.RecommendationsRepositoryImpl
+import com.daniel.spotyinsights.data.repository.TopArtistsRepositoryImpl
 import com.daniel.spotyinsights.data.repository.TopTracksRepositoryImpl
+import com.daniel.spotyinsights.domain.repository.RecommendationsRepository
+import com.daniel.spotyinsights.domain.repository.TopArtistsRepository
 import com.daniel.spotyinsights.domain.repository.TopTracksRepository
 import dagger.Module
 import dagger.Provides
@@ -39,6 +44,12 @@ object DataModule {
 
     @Provides
     @Singleton
+    fun provideArtistDao(database: SpotifyDatabase): ArtistDao {
+        return database.artistDao()
+    }
+
+    @Provides
+    @Singleton
     fun provideSpotifyApiService(retrofit: Retrofit): SpotifyApiService {
         return retrofit.create(SpotifyApiService::class.java)
     }
@@ -50,5 +61,23 @@ object DataModule {
         trackDao: TrackDao
     ): TopTracksRepository {
         return TopTracksRepositoryImpl(spotifyApiService, trackDao)
+    }
+
+    @Provides
+    @Singleton
+    fun provideTopArtistsRepository(
+        spotifyApiService: SpotifyApiService,
+        artistDao: ArtistDao
+    ): TopArtistsRepository {
+        return TopArtistsRepositoryImpl(spotifyApiService, artistDao)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRecommendationsRepository(
+        spotifyApiService: SpotifyApiService,
+        trackDao: TrackDao
+    ): RecommendationsRepository {
+        return RecommendationsRepositoryImpl(spotifyApiService, trackDao)
     }
 } 

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/SpotifyDatabase.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/SpotifyDatabase.kt
@@ -2,6 +2,7 @@ package com.daniel.spotyinsights.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.daniel.spotyinsights.data.local.dao.ArtistDao
 import com.daniel.spotyinsights.data.local.dao.TrackDao
 import com.daniel.spotyinsights.data.local.entity.*
 
@@ -17,6 +18,7 @@ import com.daniel.spotyinsights.data.local.entity.*
 )
 abstract class SpotifyDatabase : RoomDatabase() {
     abstract fun trackDao(): TrackDao
+    abstract fun artistDao(): ArtistDao
 
     companion object {
         const val DATABASE_NAME = "spotify_database"

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/dao/ArtistDao.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/dao/ArtistDao.kt
@@ -1,0 +1,21 @@
+package com.daniel.spotyinsights.data.local.dao
+
+import androidx.room.*
+import com.daniel.spotyinsights.data.local.entity.ArtistEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ArtistDao {
+    @Query("""
+        SELECT * FROM artists 
+        WHERE fetchTimeMs >= :minFetchTimeMs 
+        ORDER BY name ASC
+    """)
+    fun getTopArtists(minFetchTimeMs: Long): Flow<List<ArtistEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArtists(artists: List<ArtistEntity>)
+
+    @Query("DELETE FROM artists WHERE fetchTimeMs < :minFetchTimeMs")
+    suspend fun deleteOldArtists(minFetchTimeMs: Long)
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/entity/ArtistEntity.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/entity/ArtistEntity.kt
@@ -1,0 +1,13 @@
+package com.daniel.spotyinsights.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "artists")
+data class ArtistEntity(
+    @PrimaryKey
+    val id: String,
+    val name: String,
+    val spotifyUrl: String,
+    val fetchTimeMs: Long // To track when the data was fetched
+) 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/api/SpotifyApiService.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/api/SpotifyApiService.kt
@@ -1,5 +1,8 @@
 package com.daniel.spotyinsights.data.network.api
 
+import com.daniel.spotyinsights.data.network.model.artist.SpotifyArtistResponse
+import com.daniel.spotyinsights.data.network.model.recommendations.SpotifyAvailableGenreSeedsResponse
+import com.daniel.spotyinsights.data.network.model.recommendations.SpotifyRecommendationsResponse
 import com.daniel.spotyinsights.data.network.model.track.SpotifyTrackResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -11,4 +14,25 @@ interface SpotifyApiService {
         @Query("limit") limit: Int = 50,
         @Query("offset") offset: Int = 0
     ): SpotifyTrackResponse
+
+    @GET("v1/me/top/artists")
+    suspend fun getTopArtists(
+        @Query("time_range") timeRange: String,
+        @Query("limit") limit: Int = 50,
+        @Query("offset") offset: Int = 0
+    ): SpotifyArtistResponse
+
+    @GET("v1/recommendations")
+    suspend fun getRecommendations(
+        @Query("seed_artists") seedArtists: String? = null,
+        @Query("seed_tracks") seedTracks: String? = null,
+        @Query("seed_genres") seedGenres: String? = null,
+        @Query("limit") limit: Int = 20,
+        @Query("min_popularity") minPopularity: Int? = null,
+        @Query("max_popularity") maxPopularity: Int? = null,
+        @Query("target_popularity") targetPopularity: Int? = null
+    ): SpotifyRecommendationsResponse
+
+    @GET("v1/recommendations/available-genre-seeds")
+    suspend fun getAvailableGenreSeeds(): SpotifyAvailableGenreSeedsResponse
 } 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/model/artist/SpotifyArtistResponse.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/model/artist/SpotifyArtistResponse.kt
@@ -1,0 +1,42 @@
+package com.daniel.spotyinsights.data.network.model.artist
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SpotifyArtistResponse(
+    @Json(name = "items")
+    val items: List<SpotifyArtist>,
+    @Json(name = "total")
+    val total: Int,
+    @Json(name = "limit")
+    val limit: Int,
+    @Json(name = "offset")
+    val offset: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyArtist(
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "name")
+    val name: String,
+    @Json(name = "external_urls")
+    val externalUrls: Map<String, String>,
+    @Json(name = "genres")
+    val genres: List<String>,
+    @Json(name = "images")
+    val images: List<SpotifyImage>,
+    @Json(name = "popularity")
+    val popularity: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyImage(
+    @Json(name = "url")
+    val url: String,
+    @Json(name = "height")
+    val height: Int?,
+    @Json(name = "width")
+    val width: Int?
+) 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/model/recommendations/SpotifyRecommendationsResponse.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/model/recommendations/SpotifyRecommendationsResponse.kt
@@ -1,0 +1,29 @@
+package com.daniel.spotyinsights.data.network.model.recommendations
+
+import com.daniel.spotyinsights.data.network.model.track.SpotifyTrack
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SpotifyRecommendationsResponse(
+    @Json(name = "tracks")
+    val tracks: List<SpotifyTrack>,
+    @Json(name = "seeds")
+    val seeds: List<SpotifyRecommendationSeed>
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyRecommendationSeed(
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "type")
+    val type: String,
+    @Json(name = "href")
+    val href: String
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyAvailableGenreSeedsResponse(
+    @Json(name = "genres")
+    val genres: List<String>
+) 

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/RecommendationsRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/RecommendationsRepositoryImpl.kt
@@ -1,0 +1,96 @@
+package com.daniel.spotyinsights.data.repository
+
+import com.daniel.spotyinsights.data.local.dao.TrackDao
+import com.daniel.spotyinsights.data.local.entity.TrackArtistCrossRef
+import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.data.network.model.recommendations.SpotifyRecommendationSeed
+import com.daniel.spotyinsights.domain.model.*
+import com.daniel.spotyinsights.domain.repository.RecommendationsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RecommendationsRepositoryImpl @Inject constructor(
+    private val spotifyApiService: SpotifyApiService,
+    private val trackDao: TrackDao
+) : RecommendationsRepository {
+
+    override fun getRecommendations(parameters: RecommendationParameters): Flow<Result<Recommendations>> {
+        // Since recommendations are highly dynamic, we don't cache them
+        // Instead, we trigger a refresh every time
+        return trackDao.getTopTracks(Long.MAX_VALUE)
+            .map { tracks ->
+                if (tracks.isEmpty()) {
+                    refreshRecommendations(parameters)
+                }
+                Result.Success(Recommendations(
+                    tracks = tracks.map { it.toDomainModel() },
+                    seeds = emptyList() // Seeds are not stored in DB
+                ))
+            }
+    }
+
+    override suspend fun getAvailableGenreSeeds(): Result<List<String>> {
+        return try {
+            val response = spotifyApiService.getAvailableGenreSeeds()
+            Result.Success(response.genres)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+
+    override suspend fun refreshRecommendations(parameters: RecommendationParameters): Result<Unit> {
+        return try {
+            val response = spotifyApiService.getRecommendations(
+                seedArtists = parameters.seedArtists.takeIf { it.isNotEmpty() }?.joinToString(","),
+                seedTracks = parameters.seedTracks.takeIf { it.isNotEmpty() }?.joinToString(","),
+                seedGenres = parameters.seedGenres.takeIf { it.isNotEmpty() }?.joinToString(","),
+                limit = parameters.limit,
+                minPopularity = parameters.minPopularity,
+                maxPopularity = parameters.maxPopularity,
+                targetPopularity = parameters.targetPopularity
+            )
+
+            val currentTimeMs = System.currentTimeMillis()
+            val tracks = mutableListOf<TrackEntity>()
+            val artists = mutableListOf<ArtistEntity>()
+            val albums = mutableListOf<AlbumEntity>()
+            val trackArtistRefs = mutableListOf<TrackArtistCrossRef>()
+
+            response.tracks.forEach { spotifyTrack ->
+                tracks.add(spotifyTrack.toTrackEntity(currentTimeMs))
+                artists.addAll(spotifyTrack.artists.map { it.toArtistEntity() })
+                albums.add(spotifyTrack.album.toAlbumEntity())
+                trackArtistRefs.addAll(
+                    spotifyTrack.artists.map { artist ->
+                        TrackArtistCrossRef(spotifyTrack.id, artist.id)
+                    }
+                )
+            }
+
+            trackDao.insertTracksWithRelations(
+                tracks = tracks,
+                artists = artists.distinctBy { it.id },
+                albums = albums.distinctBy { it.id },
+                trackArtistCrossRefs = trackArtistRefs
+            )
+
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+
+    private fun SpotifyRecommendationSeed.toDomainModel() = RecommendationSeed(
+        id = id,
+        type = when (type.lowercase()) {
+            "artist" -> SeedType.ARTIST
+            "track" -> SeedType.TRACK
+            "genre" -> SeedType.GENRE
+            else -> throw IllegalArgumentException("Unknown seed type: $type")
+        },
+        href = href
+    )
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/TopArtistsRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/TopArtistsRepositoryImpl.kt
@@ -1,0 +1,72 @@
+package com.daniel.spotyinsights.data.repository
+
+import com.daniel.spotyinsights.data.local.dao.ArtistDao
+import com.daniel.spotyinsights.data.local.entity.ArtistEntity
+import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.data.network.model.artist.SpotifyArtist
+import com.daniel.spotyinsights.domain.model.Artist
+import com.daniel.spotyinsights.domain.model.Result
+import com.daniel.spotyinsights.domain.repository.TimeRange
+import com.daniel.spotyinsights.domain.repository.TopArtistsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TopArtistsRepositoryImpl @Inject constructor(
+    private val spotifyApiService: SpotifyApiService,
+    private val artistDao: ArtistDao
+) : TopArtistsRepository {
+
+    override fun getTopArtists(timeRange: TimeRange): Flow<Result<List<Artist>>> {
+        val minFetchTimeMs = System.currentTimeMillis() - CACHE_DURATION_MS
+        return artistDao.getTopArtists(minFetchTimeMs)
+            .map { artists ->
+                Result.Success(artists.map { it.toDomainModel() })
+            }
+    }
+
+    override suspend fun refreshTopArtists(timeRange: TimeRange): Result<Unit> {
+        return try {
+            val response = spotifyApiService.getTopArtists(
+                timeRange = timeRange.toApiValue(),
+                limit = 50
+            )
+
+            val currentTimeMs = System.currentTimeMillis()
+            val artists = response.items.map { it.toArtistEntity(currentTimeMs) }
+
+            artistDao.insertArtists(artists)
+            artistDao.deleteOldArtists(currentTimeMs - CACHE_DURATION_MS)
+
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+
+    private fun TimeRange.toApiValue(): String = when (this) {
+        TimeRange.SHORT_TERM -> "short_term"
+        TimeRange.MEDIUM_TERM -> "medium_term"
+        TimeRange.LONG_TERM -> "long_term"
+    }
+
+    private fun ArtistEntity.toDomainModel() = Artist(
+        id = id,
+        name = name,
+        spotifyUrl = spotifyUrl
+    )
+
+    private fun SpotifyArtist.toArtistEntity(fetchTimeMs: Long) = ArtistEntity(
+        id = id,
+        name = name,
+        spotifyUrl = externalUrls["spotify"] ?: "",
+        fetchTimeMs = fetchTimeMs
+    )
+
+    companion object {
+        private val CACHE_DURATION_MS = TimeUnit.HOURS.toMillis(24) // Cache for 24 hours
+    }
+} 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/di/DomainModule.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/di/DomainModule.kt
@@ -1,0 +1,64 @@
+package com.daniel.spotyinsights.domain.di
+
+import com.daniel.spotyinsights.domain.repository.RecommendationsRepository
+import com.daniel.spotyinsights.domain.repository.TopArtistsRepository
+import com.daniel.spotyinsights.domain.repository.TopTracksRepository
+import com.daniel.spotyinsights.domain.usecase.artist.GetTopArtistsUseCase
+import com.daniel.spotyinsights.domain.usecase.artist.RefreshTopArtistsUseCase
+import com.daniel.spotyinsights.domain.usecase.recommendations.GetGenreSeedsUseCase
+import com.daniel.spotyinsights.domain.usecase.recommendations.GetRecommendationsUseCase
+import com.daniel.spotyinsights.domain.usecase.recommendations.RefreshRecommendationsUseCase
+import com.daniel.spotyinsights.domain.usecase.track.GetTopTracksUseCase
+import com.daniel.spotyinsights.domain.usecase.track.RefreshTopTracksUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DomainModule {
+
+    @Provides
+    @Singleton
+    fun provideGetTopTracksUseCase(repository: TopTracksRepository): GetTopTracksUseCase {
+        return GetTopTracksUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRefreshTopTracksUseCase(repository: TopTracksRepository): RefreshTopTracksUseCase {
+        return RefreshTopTracksUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetTopArtistsUseCase(repository: TopArtistsRepository): GetTopArtistsUseCase {
+        return GetTopArtistsUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRefreshTopArtistsUseCase(repository: TopArtistsRepository): RefreshTopArtistsUseCase {
+        return RefreshTopArtistsUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetRecommendationsUseCase(repository: RecommendationsRepository): GetRecommendationsUseCase {
+        return GetRecommendationsUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetGenreSeedsUseCase(repository: RecommendationsRepository): GetGenreSeedsUseCase {
+        return GetGenreSeedsUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRefreshRecommendationsUseCase(repository: RecommendationsRepository): RefreshRecommendationsUseCase {
+        return RefreshRecommendationsUseCase(repository)
+    }
+} 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/artist/GetTopArtistsUseCase.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/artist/GetTopArtistsUseCase.kt
@@ -1,0 +1,16 @@
+package com.daniel.spotyinsights.domain.usecase.artist
+
+import com.daniel.spotyinsights.domain.model.Artist
+import com.daniel.spotyinsights.domain.model.Result
+import com.daniel.spotyinsights.domain.repository.TimeRange
+import com.daniel.spotyinsights.domain.repository.TopArtistsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetTopArtistsUseCase @Inject constructor(
+    private val repository: TopArtistsRepository
+) {
+    operator fun invoke(timeRange: TimeRange): Flow<Result<List<Artist>>> {
+        return repository.getTopArtists(timeRange)
+    }
+} 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/artist/RefreshTopArtistsUseCase.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/artist/RefreshTopArtistsUseCase.kt
@@ -1,0 +1,14 @@
+package com.daniel.spotyinsights.domain.usecase.artist
+
+import com.daniel.spotyinsights.domain.model.Result
+import com.daniel.spotyinsights.domain.repository.TimeRange
+import com.daniel.spotyinsights.domain.repository.TopArtistsRepository
+import javax.inject.Inject
+
+class RefreshTopArtistsUseCase @Inject constructor(
+    private val repository: TopArtistsRepository
+) {
+    suspend operator fun invoke(timeRange: TimeRange): Result<Unit> {
+        return repository.refreshTopArtists(timeRange)
+    }
+} 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/recommendations/GetRecommendationsUseCase.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/recommendations/GetRecommendationsUseCase.kt
@@ -1,7 +1,7 @@
 package com.daniel.spotyinsights.domain.usecase.recommendations
 
-import com.daniel.spotyinsights.domain.model.Recommendations
 import com.daniel.spotyinsights.domain.model.RecommendationParameters
+import com.daniel.spotyinsights.domain.model.Recommendations
 import com.daniel.spotyinsights.domain.model.Result
 import com.daniel.spotyinsights.domain.repository.RecommendationsRepository
 import kotlinx.coroutines.flow.Flow


### PR DESCRIPTION
This PR adds support for top artists and recommendations features, including:

### Top Artists Feature
- Add `ArtistEntity` with fetch time support for caching
- Create `ArtistDao` for database operations
- Implement network models for artist responses
- Add `TopArtistsRepositoryImpl` with caching mechanism
- Create use cases:
  - `GetTopArtistsUseCase`
  - `RefreshTopArtistsUseCase`

### Recommendations Feature
- Create network models for recommendations and genre seeds
- Implement `RecommendationsRepositoryImpl`
- Add use cases:
  - `GetRecommendationsUseCase`
  - `GetGenreSeedsUseCase`
  - `RefreshRecommendationsUseCase`

### Common Changes
- Update `SpotifyApiService` with new endpoints
- Update `SpotifyDatabase` to include `ArtistDao`
- Add `DomainModule` for dependency injection of use cases
- Update `DataModule` to provide new repositories

### Next Steps
- Implement ViewModels for both features
- Create UI components
- Add navigation
- Implement error handling and loading states