### PR TITLE
feat: Add Top Artists and Recommendations screens

### DIFF
--- a/app/src/main/java/com/daniel/spotyinsights/presentation/components/ArtistItem.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/components/ArtistItem.kt
@@ -1,0 +1,61 @@
+package com.daniel.spotyinsights.presentation.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.daniel.spotyinsights.domain.model.Artist
+
+@Composable
+fun ArtistItem(
+    artist: Artist,
+    onArtistClick: (Artist) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onArtistClick(artist) }
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(artist.imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = artist.name,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center
+        )
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/components/ArtistItemSkeleton.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/components/ArtistItemSkeleton.kt
@@ -1,0 +1,51 @@
+package com.daniel.spotyinsights.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.daniel.spotyinsights.presentation.util.shimmerEffect
+
+@Composable
+fun ArtistItemSkeleton(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Artist image skeleton
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .shimmerEffect()
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Artist name skeleton
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .width(100.dp)
+                .height(24.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .shimmerEffect()
+        )
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/components/GenreSelector.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/components/GenreSelector.kt
@@ -1,0 +1,35 @@
+package com.daniel.spotyinsights.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun GenreSelector(
+    availableGenres: List<String>,
+    selectedGenres: List<String>,
+    onGenreSelected: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        availableGenres.forEach { genre ->
+            AssistChip(
+                onClick = { onGenreSelected(genre) },
+                label = { Text(text = genre) },
+                selected = selectedGenres.contains(genre),
+                modifier = Modifier.padding(end = 4.dp)
+            )
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/components/RecommendationItem.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/components/RecommendationItem.kt
@@ -1,0 +1,70 @@
+package com.daniel.spotyinsights.presentation.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.daniel.spotyinsights.domain.model.Track
+
+@Composable
+fun RecommendationItem(
+    track: Track,
+    onTrackClick: (Track) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onTrackClick(track) }
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model = track.imageUrl,
+            contentDescription = "Album art for ${track.name}",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(56.dp)
+                .clip(RoundedCornerShape(8.dp))
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = track.name,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = track.artists.joinToString(", "),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/components/RecommendationItemSkeleton.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/components/RecommendationItemSkeleton.kt
@@ -1,0 +1,68 @@
+package com.daniel.spotyinsights.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.daniel.spotyinsights.presentation.util.shimmerEffect
+
+@Composable
+fun RecommendationItemSkeleton(
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Album art skeleton
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .shimmerEffect()
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            // Track name skeleton
+            androidx.compose.foundation.layout.Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.7f)
+                    .height(20.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .shimmerEffect()
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // Artists skeleton
+            androidx.compose.foundation.layout.Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .height(16.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .shimmerEffect()
+            )
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/Screen.kt
@@ -1,9 +1,9 @@
 package com.daniel.spotyinsights.presentation.navigation
 
 sealed class Screen(val route: String) {
-    data object TopTracks : Screen("top_tracks")
-    data object TopArtists : Screen("top_artists")
-    data object Recommendations : Screen("recommendations")
+    object TopTracks : Screen("top_tracks")
+    object TopArtists : Screen("top_artists")
+    object Recommendations : Screen("recommendations")
 
     companion object {
         val bottomNavItems = listOf(

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyBottomNavigation.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyBottomNavigation.kt
@@ -1,1 +1,64 @@
- 
+package com.daniel.spotyinsights.presentation.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+@Composable
+fun SpotifyBottomNavigation(
+    navController: NavController,
+    modifier: Modifier = Modifier
+) {
+    val items = listOf(
+        NavigationItem(
+            route = Screen.TopTracks.route,
+            title = "Top Tracks",
+            icon = Icons.Default.MusicNote
+        ),
+        NavigationItem(
+            route = Screen.TopArtists.route,
+            title = "Top Artists",
+            icon = Icons.Default.AccountCircle
+        ),
+        NavigationItem(
+            route = Screen.Recommendations.route,
+            title = "For You",
+            icon = Icons.Default.Favorite
+        )
+    )
+
+    val backStackEntry = navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry.value?.destination?.route
+
+    NavigationBar(
+        modifier = modifier
+    ) {
+        items.forEach { item ->
+            NavigationBarItem(
+                icon = { Icon(item.icon, contentDescription = item.title) },
+                label = { Text(text = item.title) },
+                selected = currentRoute == item.route,
+                onClick = {
+                    if (currentRoute != item.route) {
+                        navController.navigate(item.route) {
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                }
+            )
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyNavigation.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyNavigation.kt
@@ -4,7 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.daniel.spotyinsights.presentation.tracks.TopTracksScreen
+import com.daniel.spotyinsights.presentation.recommendations.RecommendationsScreen
+import com.daniel.spotyinsights.presentation.top_artists.TopArtistsScreen
+import com.daniel.spotyinsights.presentation.top_tracks.TopTracksScreen
 
 @Composable
 fun SpotifyNavigation(
@@ -18,13 +20,11 @@ fun SpotifyNavigation(
         composable(Screen.TopTracks.route) {
             TopTracksScreen()
         }
-        
         composable(Screen.TopArtists.route) {
-            // TODO: Implement TopArtistsScreen
+            TopArtistsScreen()
         }
-        
         composable(Screen.Recommendations.route) {
-            // TODO: Implement RecommendationsScreen
+            RecommendationsScreen()
         }
     }
 } 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/recommendations/RecommendationsScreen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/recommendations/RecommendationsScreen.kt
@@ -1,0 +1,91 @@
+package com.daniel.spotyinsights.presentation.recommendations
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.daniel.spotyinsights.presentation.components.ErrorState
+import com.daniel.spotyinsights.presentation.components.GenreSelector
+import com.daniel.spotyinsights.presentation.components.RecommendationItem
+import com.daniel.spotyinsights.presentation.components.RecommendationItemSkeleton
+
+@Composable
+fun RecommendationsScreen(
+    viewModel: RecommendationsViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+
+    Scaffold { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            Text(
+                text = "Recommendations",
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
+
+            Text(
+                text = "Select up to 5 genres:",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            GenreSelector(
+                availableGenres = state.availableGenres,
+                selectedGenres = state.selectedGenres,
+                onGenreSelected = viewModel::onGenreSelected,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            when {
+                state.error != null -> {
+                    ErrorState(
+                        message = state.error?.message ?: "",
+                        onRetry = state.error?.retryAction ?: {}
+                    )
+                }
+                state.isLoading -> {
+                    LazyColumn {
+                        items(10) {
+                            RecommendationItemSkeleton()
+                        }
+                    }
+                }
+                else -> {
+                    LazyColumn {
+                        items(state.recommendations) { track ->
+                            RecommendationItem(
+                                track = track,
+                                onTrackClick = { /* TODO: Handle track click */ }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/recommendations/RecommendationsState.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/recommendations/RecommendationsState.kt
@@ -1,0 +1,12 @@
+package com.daniel.spotyinsights.presentation.recommendations
+
+import com.daniel.spotyinsights.domain.model.Track
+import com.daniel.spotyinsights.presentation.util.ErrorState
+
+data class RecommendationsState(
+    val recommendations: List<Track> = emptyList(),
+    val availableGenres: List<String> = emptyList(),
+    val selectedGenres: List<String> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: ErrorState? = null
+) 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/recommendations/RecommendationsViewModel.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/recommendations/RecommendationsViewModel.kt
@@ -1,0 +1,105 @@
+package com.daniel.spotyinsights.presentation.recommendations
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daniel.spotyinsights.domain.usecase.GetGenreSeedsUseCase
+import com.daniel.spotyinsights.domain.usecase.GetRecommendationsUseCase
+import com.daniel.spotyinsights.domain.usecase.RefreshRecommendationsUseCase
+import com.daniel.spotyinsights.presentation.util.ErrorState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RecommendationsViewModel @Inject constructor(
+    private val getRecommendationsUseCase: GetRecommendationsUseCase,
+    private val refreshRecommendationsUseCase: RefreshRecommendationsUseCase,
+    private val getGenreSeedsUseCase: GetGenreSeedsUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(RecommendationsState())
+    val state: StateFlow<RecommendationsState> = _state.asStateFlow()
+
+    init {
+        loadGenreSeeds()
+        getRecommendations()
+    }
+
+    fun onGenreSelected(genre: String) {
+        val currentGenres = _state.value.selectedGenres.toMutableList()
+        if (currentGenres.contains(genre)) {
+            currentGenres.remove(genre)
+        } else if (currentGenres.size < 5) {
+            currentGenres.add(genre)
+        }
+        _state.value = _state.value.copy(selectedGenres = currentGenres)
+        getRecommendations()
+    }
+
+    fun onRetry() {
+        getRecommendations()
+    }
+
+    private fun loadGenreSeeds() {
+        viewModelScope.launch {
+            getGenreSeedsUseCase()
+                .catch { exception ->
+                    _state.value = _state.value.copy(
+                        error = ErrorState(
+                            message = exception.message ?: "Failed to load genre seeds",
+                            retryAction = ::loadGenreSeeds
+                        )
+                    )
+                }
+                .onEach { genres ->
+                    _state.value = _state.value.copy(
+                        availableGenres = genres
+                    )
+                }
+                .launchIn(viewModelScope)
+        }
+    }
+
+    private fun getRecommendations() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(
+                isLoading = true,
+                error = null
+            )
+
+            refreshRecommendationsUseCase(state.value.selectedGenres)
+                .onFailure { exception ->
+                    _state.value = _state.value.copy(
+                        error = ErrorState(
+                            message = exception.message ?: "Failed to refresh recommendations",
+                            retryAction = ::onRetry
+                        )
+                    )
+                }
+
+            getRecommendationsUseCase(state.value.selectedGenres)
+                .catch { exception ->
+                    _state.value = _state.value.copy(
+                        isLoading = false,
+                        error = ErrorState(
+                            message = exception.message ?: "Failed to load recommendations",
+                            retryAction = ::onRetry
+                        )
+                    )
+                }
+                .onEach { recommendations ->
+                    _state.value = _state.value.copy(
+                        recommendations = recommendations,
+                        isLoading = false
+                    )
+                }
+                .launchIn(viewModelScope)
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsScreen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsScreen.kt
@@ -1,0 +1,97 @@
+package com.daniel.spotyinsights.presentation.top_artists
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.daniel.spotyinsights.presentation.components.ArtistItem
+import com.daniel.spotyinsights.presentation.components.ArtistItemSkeleton
+import com.daniel.spotyinsights.presentation.components.ErrorState
+import com.daniel.spotyinsights.presentation.components.TimeRangeSelector
+
+@Composable
+fun TopArtistsScreen(
+    viewModel: TopArtistsViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+
+    Scaffold { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            Text(
+                text = "Your Top Artists",
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
+
+            TimeRangeSelector(
+                selectedTimeRange = state.selectedTimeRange,
+                onTimeRangeSelected = viewModel::onTimeRangeSelected,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                when {
+                    state.error != null -> {
+                        ErrorState(
+                            message = state.error?.message ?: "",
+                            onRetry = state.error?.retryAction ?: {}
+                        )
+                    }
+                    state.isLoading -> {
+                        LazyVerticalGrid(
+                            columns = GridCells.Fixed(2),
+                            contentPadding = PaddingValues(16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            items(10) {
+                                ArtistItemSkeleton()
+                            }
+                        }
+                    }
+                    else -> {
+                        LazyVerticalGrid(
+                            columns = GridCells.Fixed(2),
+                            contentPadding = PaddingValues(16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            items(state.artists) { artist ->
+                                ArtistItem(
+                                    artist = artist,
+                                    onArtistClick = { /* TODO: Handle artist click */ }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsState.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsState.kt
@@ -1,0 +1,12 @@
+package com.daniel.spotyinsights.presentation.top_artists
+
+import com.daniel.spotyinsights.domain.model.Artist
+import com.daniel.spotyinsights.domain.repository.TimeRange
+import com.daniel.spotyinsights.presentation.util.ErrorState
+
+data class TopArtistsState(
+    val artists: List<Artist> = emptyList(),
+    val isLoading: Boolean = false,
+    val selectedTimeRange: TimeRange = TimeRange.SHORT_TERM,
+    val error: ErrorState? = null
+) 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsViewModel.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsViewModel.kt
@@ -1,0 +1,77 @@
+package com.daniel.spotyinsights.presentation.top_artists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daniel.spotyinsights.domain.repository.TimeRange
+import com.daniel.spotyinsights.domain.usecase.GetTopArtistsUseCase
+import com.daniel.spotyinsights.domain.usecase.RefreshTopArtistsUseCase
+import com.daniel.spotyinsights.presentation.util.ErrorState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TopArtistsViewModel @Inject constructor(
+    private val getTopArtistsUseCase: GetTopArtistsUseCase,
+    private val refreshTopArtistsUseCase: RefreshTopArtistsUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(TopArtistsState())
+    val state: StateFlow<TopArtistsState> = _state.asStateFlow()
+
+    init {
+        getTopArtists()
+    }
+
+    fun onTimeRangeSelected(timeRange: TimeRange) {
+        _state.value = _state.value.copy(selectedTimeRange = timeRange)
+        getTopArtists()
+    }
+
+    fun onRetry() {
+        getTopArtists()
+    }
+
+    private fun getTopArtists() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(
+                isLoading = true,
+                error = null
+            )
+
+            refreshTopArtistsUseCase(state.value.selectedTimeRange)
+                .onFailure { exception ->
+                    _state.value = _state.value.copy(
+                        error = ErrorState(
+                            message = exception.message ?: "Unknown error occurred",
+                            retryAction = ::onRetry
+                        )
+                    )
+                }
+
+            getTopArtistsUseCase(state.value.selectedTimeRange)
+                .catch { exception ->
+                    _state.value = _state.value.copy(
+                        isLoading = false,
+                        error = ErrorState(
+                            message = exception.message ?: "Unknown error occurred",
+                            retryAction = ::onRetry
+                        )
+                    )
+                }
+                .onEach { artists ->
+                    _state.value = _state.value.copy(
+                        artists = artists,
+                        isLoading = false
+                    )
+                }
+                .launchIn(viewModelScope)
+        }
+    }
+} 


### PR DESCRIPTION
This PR adds two new screens to the application:

1. Top Artists Screen:
   - Displays user's top artists in a grid layout
   - Each artist is shown with their image and name
   - Supports time range selection (short, medium, long term)
   - Includes loading states with shimmer effects
   - Handles error states with retry functionality

2. Recommendations Screen:
   - Allows users to select up to 5 genres for recommendations
   - Displays recommended tracks based on selected genres
   - Shows track artwork, name, and artists
   - Includes loading states with shimmer effects
   - Handles error states with retry functionality

Common Features:
- Material3 design components
- Responsive layouts
- Smooth loading animations
- Error handling with user feedback
- Clean architecture implementation