### PR TITLE
fix: handle genre and image cross-references properly

### DIFF
--- a/app/src/main/java/com/daniel/spotyinsights/presentation/components/ArtistItem.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/components/ArtistItem.kt
@@ -38,10 +38,10 @@ fun ArtistItem(
     ) {
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
-                .data(artist.images.first())
+                .data(artist.images.firstOrNull())
                 .crossfade(true)
                 .build(),
-            contentDescription = null,
+            contentDescription = "Artist image for ${artist.name}",
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .size(120.dp)

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsViewModel.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsViewModel.kt
@@ -1,89 +1,193 @@
 package com.daniel.spotyinsights.presentation.top_artists
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.daniel.spotyinsights.base.BaseViewModel
+import com.daniel.spotyinsights.base.UiEffect
+import com.daniel.spotyinsights.base.UiEvent
+import com.daniel.spotyinsights.base.UiState
 import com.daniel.spotyinsights.domain.model.DetailedArtist
 import com.daniel.spotyinsights.domain.model.Result
 import com.daniel.spotyinsights.domain.repository.TimeRange
 import com.daniel.spotyinsights.domain.usecase.artist.GetTopArtistsUseCase
+import com.daniel.spotyinsights.domain.usecase.artist.RefreshTopArtistsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class TopArtistsViewModel @Inject constructor(
-    private val getTopArtistsUseCase: GetTopArtistsUseCase
-) : ViewModel() {
+    private val getTopArtistsUseCase: GetTopArtistsUseCase,
+    private val refreshTopArtistsUseCase: RefreshTopArtistsUseCase
+) : BaseViewModel<TopArtistsState, TopArtistsEvent, TopArtistsEffect>() {
 
-    private val _uiState = MutableStateFlow(TopArtistsState())
-    val uiState: StateFlow<TopArtistsState> = _uiState.asStateFlow()
+    private var currentLoadJob: Job? = null
+    private var isInitialLoad = true
 
-    private val _effect = MutableSharedFlow<TopArtistsEffect>()
-    val effect: SharedFlow<TopArtistsEffect> = _effect.asSharedFlow()
+    override fun createInitialState(): TopArtistsState = TopArtistsState()
 
     init {
         loadArtists()
     }
 
-    fun setEvent(event: TopArtistsEvent) {
+    override fun handleEvent(event: TopArtistsEvent) {
         when (event) {
             is TopArtistsEvent.TimeRangeSelected -> {
-                _uiState.update { it.copy(selectedTimeRange = event.timeRange) }
-                loadArtists()
+                if (event.timeRange != uiState.value.selectedTimeRange) {
+                    setState {
+                        copy(
+                            selectedTimeRange = event.timeRange,
+                            artists = emptyList(), // Clear current list to avoid showing old data
+                            isLoading = true
+                        )
+                    }
+                    loadArtists(forceRefresh = true)
+                }
             }
-            TopArtistsEvent.Refresh -> loadArtists()
+
+            TopArtistsEvent.Refresh -> onRefresh()
         }
     }
 
-    private fun loadArtists() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, error = null) }
+    private fun onRefresh() {
+        loadArtists(forceRefresh = true)
+    }
+
+    private fun loadArtists(forceRefresh: Boolean = false) {
+        // Cancel any ongoing loading operation
+        currentLoadJob?.cancel()
+
+        currentLoadJob = viewModelScope.launch {
             try {
-                getTopArtistsUseCase(uiState.value.selectedTimeRange).collect { result ->
-                    when (result) {
+                if (forceRefresh) {
+                    setState { copy(isRefreshing = true) }
+                    when (val result = refreshTopArtistsUseCase(uiState.value.selectedTimeRange)) {
                         is Result.Success -> {
-                            _uiState.update { it.copy(
-                                artists = result.data,
-                                isLoading = false,
-                                error = null
-                            ) }
+                            setState { copy(error = null) }
                         }
+
                         is Result.Error -> {
-                            handleError(Exception(result.exception.message))
+                            setState {
+                                copy(
+                                    error = result.exception.message ?: "Failed to refresh artists",
+                                    isRefreshing = false,
+                                    isLoading = false
+                                )
+                            }
+                            setEffect {
+                                TopArtistsEffect.ShowError(
+                                    result.exception.message ?: "Failed to refresh artists"
+                                )
+                            }
+                            return@launch
                         }
+
                         is Result.Loading -> {
-                            _uiState.update { it.copy(isLoading = true) }
+                            // Loading state is handled by isRefreshing flag
                         }
                     }
                 }
+
+                getTopArtistsUseCase(uiState.value.selectedTimeRange)
+                    .onEach { result ->
+                        when (result) {
+                            is Result.Success -> {
+                                if (result.data.isEmpty() && isInitialLoad) {
+                                    // If it's the initial load and we got empty data, trigger a refresh
+                                    isInitialLoad = false
+                                    loadArtists(forceRefresh = true)
+                                } else {
+                                    setState {
+                                        copy(
+                                            artists = result.data,
+                                            isLoading = false,
+                                            error = null,
+                                            isRefreshing = false
+                                        )
+                                    }
+                                    isInitialLoad = false
+                                }
+                            }
+
+                            is Result.Error -> {
+                                setState {
+                                    copy(
+                                        error = result.exception.message
+                                            ?: "Failed to load artists",
+                                        isLoading = false,
+                                        isRefreshing = false
+                                    )
+                                }
+                                setEffect {
+                                    TopArtistsEffect.ShowError(
+                                        result.exception.message ?: "Failed to load artists"
+                                    )
+                                }
+                            }
+
+                            is Result.Loading -> {
+                                if (!forceRefresh) {
+                                    setState {
+                                        copy(
+                                            isLoading = true,
+                                            error = null
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .catch { throwable ->
+                        if (currentLoadJob?.isCancelled == false) {
+                            setState {
+                                copy(
+                                    error = throwable.message ?: "Unknown error occurred",
+                                    isLoading = false,
+                                    isRefreshing = false
+                                )
+                            }
+                            setEffect {
+                                TopArtistsEffect.ShowError(
+                                    throwable.message ?: "Unknown error occurred"
+                                )
+                            }
+                        }
+                    }
+                    .launchIn(this)
             } catch (e: Exception) {
-                handleError(e)
+                if (currentLoadJob?.isCancelled == false) {
+                    setState {
+                        copy(
+                            error = e.message ?: "Unknown error occurred",
+                            isLoading = false,
+                            isRefreshing = false
+                        )
+                    }
+                    setEffect {
+                        TopArtistsEffect.ShowError(
+                            e.message ?: "Unknown error occurred"
+                        )
+                    }
+                }
             }
         }
     }
 
-    private suspend fun handleError(error: Exception) {
-        _uiState.update { it.copy(
-            isLoading = false,
-            error = error.message ?: "An unexpected error occurred"
-        ) }
-        _effect.emit(TopArtistsEffect.ShowError(error.message ?: "An unexpected error occurred"))
+    override fun onCleared() {
+        super.onCleared()
+        currentLoadJob?.cancel()
     }
 }
 
-sealed interface TopArtistsEvent {
+sealed interface TopArtistsEvent : UiEvent {
     data class TimeRangeSelected(val timeRange: TimeRange) : TopArtistsEvent
     data object Refresh : TopArtistsEvent
 }
 
-sealed interface TopArtistsEffect {
+sealed interface TopArtistsEffect : UiEffect {
     data class ShowError(val message: String) : TopArtistsEffect
 }
 
@@ -91,5 +195,6 @@ data class TopArtistsState(
     val artists: List<DetailedArtist> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
-    val selectedTimeRange: TimeRange = TimeRange.MEDIUM_TERM
-)
+    val selectedTimeRange: TimeRange = TimeRange.MEDIUM_TERM,
+    val isRefreshing: Boolean = false
+) : UiState

--- a/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
@@ -1,6 +1,7 @@
 package com.daniel.spotyinsights.data.di
 
 import android.content.Context
+import android.util.Log
 import androidx.room.Room
 import com.daniel.spotyinsights.data.local.SpotifyDatabase
 import com.daniel.spotyinsights.data.local.dao.ArtistDao
@@ -20,6 +21,8 @@ import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import javax.inject.Named
 import javax.inject.Singleton
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -30,13 +33,28 @@ object DataModule {
     fun provideSpotifyDatabase(
         @ApplicationContext context: Context
     ): SpotifyDatabase {
+        Log.d("DataModule", "Creating SpotifyDatabase instance")
         return Room.databaseBuilder(
             context,
             SpotifyDatabase::class.java,
             SpotifyDatabase.DATABASE_NAME
         )
-        .addMigrations(SpotifyDatabase.MIGRATION_2_3)
+        .addMigrations(
+            SpotifyDatabase.MIGRATION_2_3,
+            SpotifyDatabase.MIGRATION_3_4
+        )
         .fallbackToDestructiveMigration()
+        .addCallback(object : RoomDatabase.Callback() {
+            override fun onCreate(db: SupportSQLiteDatabase) {
+                super.onCreate(db)
+                Log.d("DataModule", "Database created")
+            }
+
+            override fun onOpen(db: SupportSQLiteDatabase) {
+                super.onOpen(db)
+                Log.d("DataModule", "Database opened")
+            }
+        })
         .build()
     }
 

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/SpotifyDatabase.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/SpotifyDatabase.kt
@@ -20,7 +20,7 @@ import com.daniel.spotyinsights.data.local.entity.*
         ArtistGenreCrossRef::class,
         ArtistImageCrossRef::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 abstract class SpotifyDatabase : RoomDatabase() {
@@ -29,6 +29,7 @@ abstract class SpotifyDatabase : RoomDatabase() {
 
     companion object {
         const val DATABASE_NAME = "spotify_database"
+        const val DATABASE_VERSION = 4
 
         val MIGRATION_2_3 = object : Migration(2, 3) {
             override fun migrate(database: SupportSQLiteDatabase) {
@@ -59,6 +60,17 @@ abstract class SpotifyDatabase : RoomDatabase() {
 
                 // Create index on artistId
                 database.execSQL("CREATE INDEX IF NOT EXISTS index_track_artist_refs_artistId ON track_artist_refs(artistId)")
+            }
+        }
+
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """
+                    ALTER TABLE detailed_artists
+                    ADD COLUMN timeRange TEXT NOT NULL DEFAULT 'medium_term'
+                    """
+                )
             }
         }
     }

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/dao/ArtistDao.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/dao/ArtistDao.kt
@@ -1,7 +1,18 @@
 package com.daniel.spotyinsights.data.local.dao
 
-import androidx.room.*
-import com.daniel.spotyinsights.data.local.entity.*
+import androidx.room.Dao
+import androidx.room.Embedded
+import androidx.room.Insert
+import androidx.room.Junction
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Relation
+import androidx.room.Transaction
+import com.daniel.spotyinsights.data.local.entity.ArtistGenreCrossRef
+import com.daniel.spotyinsights.data.local.entity.ArtistImageCrossRef
+import com.daniel.spotyinsights.data.local.entity.DetailedArtistEntity
+import com.daniel.spotyinsights.data.local.entity.GenreEntity
+import com.daniel.spotyinsights.data.local.entity.ImageEntity
 import kotlinx.coroutines.flow.Flow
 
 data class ArtistWithRelations(
@@ -31,12 +42,21 @@ data class ArtistWithRelations(
 @Dao
 interface ArtistDao {
     @Transaction
-    @Query("""
+    @Query(
+        """
         SELECT * FROM detailed_artists 
         WHERE fetchTimeMs >= :minFetchTimeMs 
+        AND timeRange = :timeRange
         ORDER BY name ASC
-    """)
-    fun getTopArtists(minFetchTimeMs: Long): Flow<List<ArtistWithRelations>>
+    """
+    )
+    fun getTopArtists(minFetchTimeMs: Long, timeRange: String): Flow<List<ArtistWithRelations>>
+
+    @Query("SELECT * FROM genres WHERE name IN (:names)")
+    suspend fun getGenresByNames(names: List<String>): List<GenreEntity>
+
+    @Query("SELECT * FROM images WHERE url IN (:urls)")
+    suspend fun getImagesByUrls(urls: List<String>): List<ImageEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertArtists(artists: List<DetailedArtistEntity>)
@@ -53,6 +73,9 @@ interface ArtistDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertArtistImageCrossRefs(crossRefs: List<ArtistImageCrossRef>)
 
+    @Query("DELETE FROM detailed_artists WHERE timeRange = :timeRange")
+    suspend fun deleteArtistsByTimeRange(timeRange: String)
+
     @Transaction
     suspend fun insertArtistsWithRelations(
         artists: List<DetailedArtistEntity>,
@@ -62,12 +85,20 @@ interface ArtistDao {
         artistImageCrossRefs: List<ArtistImageCrossRef>
     ) {
         insertArtists(artists)
-        insertGenres(genres)
-        insertImages(images)
+        if (genres.isNotEmpty()) {
+            insertGenres(genres)
+        }
+        if (images.isNotEmpty()) {
+            insertImages(images)
+        }
         insertArtistGenreCrossRefs(artistGenreCrossRefs)
         insertArtistImageCrossRefs(artistImageCrossRefs)
     }
 
     @Query("DELETE FROM detailed_artists WHERE fetchTimeMs < :minFetchTimeMs")
     suspend fun deleteOldArtists(minFetchTimeMs: Long)
+
+    @Transaction
+    @Query("SELECT * FROM detailed_artists WHERE timeRange = :timeRange")
+    fun getArtistsByTimeRange(timeRange: String): Flow<List<ArtistWithRelations>>
 }

--- a/data/src/main/java/com/daniel/spotyinsights/data/local/entity/DetailedArtistEntity.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/local/entity/DetailedArtistEntity.kt
@@ -2,6 +2,7 @@ package com.daniel.spotyinsights.data.local.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.daniel.spotyinsights.domain.repository.TimeRange
 
 @Entity(tableName = "detailed_artists")
 data class DetailedArtistEntity(
@@ -10,7 +11,8 @@ data class DetailedArtistEntity(
     val name: String,
     val spotifyUrl: String,
     val popularity: Int,
-    val fetchTimeMs: Long // To track when the data was fetched
+    val fetchTimeMs: Long, // To track when the data was fetched
+    val timeRange: String = "medium_term" // SHORT_TERM, MEDIUM_TERM, or LONG_TERM
 )
 
 @Entity(tableName = "track_artists")

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/model/artist/SpotifyArtistMapper.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/model/artist/SpotifyArtistMapper.kt
@@ -1,0 +1,33 @@
+package com.daniel.spotyinsights.data.network.model.artist
+
+import com.daniel.spotyinsights.data.local.entity.DetailedArtistEntity
+import com.daniel.spotyinsights.data.local.entity.GenreEntity
+import com.daniel.spotyinsights.data.local.entity.ImageEntity
+
+fun SpotifyArtist.toDetailedArtistEntity(
+    fetchTimeMs: Long,
+    timeRange: String
+): Pair<DetailedArtistEntity, Pair<List<GenreEntity>, List<ImageEntity>>> {
+    val artist = DetailedArtistEntity(
+        id = id,
+        name = name,
+        spotifyUrl = externalUrls["spotify"] ?: "",
+        popularity = popularity,
+        fetchTimeMs = fetchTimeMs,
+        timeRange = timeRange
+    )
+
+    val genreEntities = genres.map { genreName ->
+        GenreEntity(name = genreName)
+    }
+
+    val imageEntities = images.map { image ->
+        ImageEntity(
+            url = image.url,
+            height = image.height,
+            width = image.width
+        )
+    }
+
+    return artist to (genreEntities to imageEntities)
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/EntityConversionUtils.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/EntityConversionUtils.kt
@@ -23,21 +23,6 @@ internal fun SpotifyTrack.toTrackEntity(fetchTimeMs: Long) = TrackEntity(
     fetchTimeMs = fetchTimeMs
 )
 
-internal fun SpotifyArtist.toDetailedArtistEntity(fetchTimeMs: Long): Pair<DetailedArtistEntity, Pair<List<GenreEntity>, List<ImageEntity>>> {
-    val detailedArtistEntity = DetailedArtistEntity(
-        id = id,
-        name = name,
-        spotifyUrl = externalUrls["spotify"] ?: "",
-        popularity = popularity,
-        fetchTimeMs = fetchTimeMs
-    )
-
-    val genreEntities = genres.map { GenreEntity(name = it) }
-    val imageEntities = images.map { ImageEntity(url = it.url, height = it.height, width = it.width) }
-
-    return Pair(detailedArtistEntity, Pair(genreEntities, imageEntities))
-}
-
 internal fun SpotifyAlbum.toAlbumEntity() = AlbumEntity(
     id = id,
     name = name,

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/TopArtistsRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/TopArtistsRepositoryImpl.kt
@@ -2,12 +2,13 @@ package com.daniel.spotyinsights.data.repository
 
 import com.daniel.spotyinsights.data.local.dao.ArtistDao
 import com.daniel.spotyinsights.data.local.dao.ArtistWithRelations
+import com.daniel.spotyinsights.data.local.entity.ArtistGenreCrossRef
+import com.daniel.spotyinsights.data.local.entity.ArtistImageCrossRef
 import com.daniel.spotyinsights.data.local.entity.DetailedArtistEntity
 import com.daniel.spotyinsights.data.local.entity.GenreEntity
 import com.daniel.spotyinsights.data.local.entity.ImageEntity
-import com.daniel.spotyinsights.data.local.entity.ArtistGenreCrossRef
-import com.daniel.spotyinsights.data.local.entity.ArtistImageCrossRef
 import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.data.network.model.artist.toDetailedArtistEntity
 import com.daniel.spotyinsights.domain.model.DetailedArtist
 import com.daniel.spotyinsights.domain.model.Result
 import com.daniel.spotyinsights.domain.repository.TimeRange
@@ -15,11 +16,11 @@ import com.daniel.spotyinsights.domain.repository.TopArtistsRepository
 import com.daniel.spotyinsights.domain.util.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.collections.map
 
 @Singleton
 class TopArtistsRepositoryImpl @Inject constructor(
@@ -27,65 +28,122 @@ class TopArtistsRepositoryImpl @Inject constructor(
     private val artistDao: ArtistDao
 ) : TopArtistsRepository {
 
+    private data class ArtistGenreCrossRefTemp(
+        val artistId: String,
+        val genreName: String
+    )
+
+    private val refreshMutex = Mutex()
+
     override fun getTopArtists(timeRange: TimeRange): Flow<Result<List<DetailedArtist>>> {
         val minFetchTimeMs = System.currentTimeMillis() - CACHE_DURATION_MS
-        return artistDao.getTopArtists(minFetchTimeMs)
-            .onEach { artists ->
-                if (artists.isEmpty()) {
-                    Logger.i("No artists found in database, triggering refresh")
-                    refreshTopArtists(timeRange)
-                }
-            }
+        return artistDao.getTopArtists(minFetchTimeMs, timeRange.toApiValue())
             .map { artists ->
-                Result.Success(artists.map { it.toDomainModel() })
+                if (artists.isEmpty()) {
+                    // If we have no data, return an empty list instead of Loading
+                    // The ViewModel will handle the refresh
+                    Result.Success(emptyList())
+                } else {
+                    Result.Success(artists.map { it.toDomainModel() })
+                }
             }
     }
 
     override suspend fun refreshTopArtists(timeRange: TimeRange): Result<Unit> {
         return try {
-            Logger.i("Refreshing top artists for time range: $timeRange")
-            val response = spotifyApiService.getTopArtists(
-                timeRange = timeRange.toApiValue(),
-                limit = 50
-            )
+            refreshMutex.withLock {
+                Logger.i("Refreshing top artists for time range: $timeRange")
+                val response = spotifyApiService.getTopArtists(
+                    timeRange = timeRange.toApiValue(),
+                    limit = 50
+                )
 
-            val currentTimeMs = System.currentTimeMillis()
-            val artists = mutableListOf<DetailedArtistEntity>()
-            val genres = mutableListOf<GenreEntity>()
-            val images = mutableListOf<ImageEntity>()
-            val artistGenreCrossRefs = mutableListOf<ArtistGenreCrossRef>()
-            val artistImageCrossRefs = mutableListOf<ArtistImageCrossRef>()
+                val currentTimeMs = System.currentTimeMillis()
+                val artists = mutableListOf<DetailedArtistEntity>()
+                val genres = mutableListOf<GenreEntity>()
+                val images = mutableListOf<ImageEntity>()
+                val artistGenreCrossRefs = mutableListOf<ArtistGenreCrossRefTemp>()
+                val imageUrlToArtistIds = mutableMapOf<String, MutableList<String>>()
 
-            response.items.forEach { spotifyArtist ->
-                val (artistEntity, genreImagePair) = spotifyArtist.toDetailedArtistEntity(currentTimeMs)
-                artists.add(artistEntity)
-                genres.addAll(genreImagePair.first)
-                images.addAll(genreImagePair.second)
+                response.items.forEach { spotifyArtist ->
+                    val (artistEntity, genreImagePair) = spotifyArtist.toDetailedArtistEntity(
+                        currentTimeMs,
+                        timeRange.toApiValue()
+                    )
+                    artists.add(artistEntity)
 
-                genreImagePair.first.forEach { genre ->
-                    artistGenreCrossRefs.add(ArtistGenreCrossRef(artistEntity.id, genre.id))
+                    // Handle genres
+                    val (genreEntities, imageEntities) = genreImagePair
+                    genres.addAll(genreEntities)
+                    // We'll create the actual cross-refs after inserting genres and getting their IDs
+                    artistGenreCrossRefs.addAll(
+                        genreEntities.map { genre ->
+                            // Temporarily store artist ID and genre name - we'll convert to proper IDs later
+                            ArtistGenreCrossRefTemp(artistEntity.id, genre.name)
+                        }
+                    )
+
+                    // Store image URLs with artist IDs for later cross-reference creation
+                    imageEntities.forEach { image ->
+                        images.add(image)
+                        imageUrlToArtistIds.getOrPut(image.url) { mutableListOf() }
+                            .add(artistEntity.id)
+                    }
                 }
 
-                genreImagePair.second.forEach { image ->
-                    artistImageCrossRefs.add(ArtistImageCrossRef(artistEntity.id, image.id))
+                // Delete old data for this time range before inserting new
+                val apiTimeRange = timeRange.toApiValue()
+                artistDao.deleteArtistsByTimeRange(apiTimeRange)
+
+                Logger.i("Inserting ${artists.size} artists into database")
+
+                // First insert artists and genres
+                artistDao.insertArtists(artists)
+                
+                // Insert genres and get their IDs
+                if (genres.isNotEmpty()) {
+                    val distinctGenres = genres.distinctBy { it.name }
+                    artistDao.insertGenres(distinctGenres)
+                    
+                    // Query back the inserted genres to get their generated IDs
+                    val insertedGenres = artistDao.getGenresByNames(distinctGenres.map { it.name })
+                    
+                    // Create genre cross-references using the generated IDs
+                    val genreCrossRefs = artistGenreCrossRefs.mapNotNull { tempRef ->
+                        insertedGenres.find { it.name == tempRef.genreName }?.let { genre ->
+                            ArtistGenreCrossRef(artistId = tempRef.artistId, genreId = genre.id)
+                        }
+                    }
+                    
+                    if (genreCrossRefs.isNotEmpty()) {
+                        artistDao.insertArtistGenreCrossRefs(genreCrossRefs)
+                    }
                 }
+
+                // Insert images and get their generated IDs
+                if (images.isNotEmpty()) {
+                    val distinctImages = images.distinctBy { it.url }
+                    artistDao.insertImages(distinctImages)
+
+                    // Query back the inserted images to get their generated IDs
+                    val insertedImages = artistDao.getImagesByUrls(distinctImages.map { it.url })
+
+                    // Create image cross-references using the generated IDs
+                    val artistImageCrossRefs = insertedImages.flatMap { image ->
+                        imageUrlToArtistIds[image.url]?.map { artistId ->
+                            ArtistImageCrossRef(artistId = artistId, imageId = image.id)
+                        } ?: emptyList()
+                    }
+
+                    if (artistImageCrossRefs.isNotEmpty()) {
+                        artistDao.insertArtistImageCrossRefs(artistImageCrossRefs)
+                    }
+                }
+
+                Result.Success(Unit)
             }
-
-            Logger.i("Inserting ${artists.size} artists into database")
-            artistDao.insertArtistsWithRelations(
-                artists = artists,
-                genres = genres.distinctBy { it.name },
-                images = images.distinctBy { it.url },
-                artistGenreCrossRefs = artistGenreCrossRefs,
-                artistImageCrossRefs = artistImageCrossRefs
-            )
-
-            artistDao.deleteOldArtists(currentTimeMs - CACHE_DURATION_MS)
-            Logger.i("Successfully refreshed top artists")
-
-            Result.Success(Unit)
         } catch (e: Exception) {
-            Logger.e("Failed to refresh top artists", e)
+            Logger.e("Error refreshing top artists", e)
             Result.Error(e)
         }
     }
@@ -106,6 +164,6 @@ class TopArtistsRepositoryImpl @Inject constructor(
     )
 
     companion object {
-        private val CACHE_DURATION_MS = TimeUnit.HOURS.toMillis(24) // Cache for 24 hours
+        private val CACHE_DURATION_MS = TimeUnit.HOURS.toMillis(1)
     }
 } 


### PR DESCRIPTION
## Changes Made
- Fixed type mismatch in `ArtistGenreCrossRef` by properly handling genre IDs
- Added temporary storage class `ArtistGenreCrossRefTemp` for managing genre references before DB insertion
- Improved database operations ordering for cross-references
- Updated entity conversion utils to handle IDs correctly
- Fixed image cross-references to use proper Long IDs

## Implementation Details
1. Created a temporary class to store artist ID and genre name pairs before having actual genre IDs
2. Modified the genre insertion process to:
   - Insert genres first
   - Query back the inserted genres to get their generated IDs
   - Create proper `ArtistGenreCrossRef` instances using actual genre IDs
3. Simplified cross-reference creation by directly mapping from temporary to final references
4. Fixed image cross-references to properly use auto-generated Long IDs

## Testing
Please verify:
- Top artists are displayed correctly with their genres
- No type mismatch errors in logs
- Database operations complete successfully
- Genre filtering works as expected

## Additional Notes
This PR fixes the issue where genre and image cross-references were not being handled properly, causing type mismatches between String and Long IDs in the database.