### PR TITLE
Add New Releases Feature

### DIFF
--- a/app/src/main/java/com/daniel/spotyinsights/presentation/components/ReleaseItem.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/components/ReleaseItem.kt
@@ -1,0 +1,115 @@
+package com.daniel.spotyinsights.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.daniel.spotyinsights.domain.model.NewRelease
+import com.daniel.spotyinsights.presentation.util.shimmerEffect
+
+@Composable
+fun ReleaseItem(
+    release: NewRelease,
+    onReleaseClick: (NewRelease) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onReleaseClick(release) }
+            .padding(8.dp)
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(release.imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(8.dp))
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = release.name,
+            style = MaterialTheme.typography.bodyLarge,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = release.artists.joinToString { it.name },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+fun ReleaseItemSkeleton(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+    ) {
+        // Album art skeleton
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .shimmerEffect()
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Release name skeleton
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .fillMaxWidth(0.8f)
+                .height(20.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .shimmerEffect()
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // Artists name skeleton
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .fillMaxWidth(0.6f)
+                .height(16.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .shimmerEffect()
+        )
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/Screen.kt
@@ -2,9 +2,9 @@ package com.daniel.spotyinsights.presentation.navigation
 
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.daniel.spotyinsights.R
 
@@ -18,24 +18,24 @@ sealed class Screen(
         icon = Icons.Filled.PlayArrow,
         labelResId = R.string.nav_top_tracks
     )
-    
+
     data object TopArtists : Screen(
         route = "top_artists",
         icon = Icons.Filled.Person,
         labelResId = R.string.nav_top_artists
     )
-    
-    data object Recommendations : Screen(
-        route = "recommendations",
-        icon = Icons.Filled.Favorite,
-        labelResId = R.string.nav_recommendations
+
+    data object NewReleases : Screen(
+        route = "new_releases",
+        icon = Icons.Filled.Star,
+        labelResId = R.string.nav_new_releases
     )
 
     companion object {
         val bottomNavItems = listOf(
             TopTracks,
             TopArtists,
-            Recommendations
+            NewReleases
         )
     }
 }

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyBottomNavigation.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyBottomNavigation.kt
@@ -9,17 +9,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import com.daniel.spotyinsights.R
+import com.daniel.spotyinsights.presentation.navigation.Screen.Companion.bottomNavItems
 
 @Composable
 fun SpotifyBottomNavigation(
     navController: NavController
 ) {
-    val items = listOf(
-        Screen.TopTracks,
-        Screen.TopArtists,
-        Screen.Recommendations
-    )
+    val items = bottomNavItems
 
     NavigationBar {
         val navBackStackEntry by navController.currentBackStackEntryAsState()

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyNavigation.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyNavigation.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.daniel.spotyinsights.presentation.recommendations.RecommendationsScreen
+import com.daniel.spotyinsights.presentation.releases.NewReleasesScreen
 import com.daniel.spotyinsights.presentation.top_artists.TopArtistsScreen
 import com.daniel.spotyinsights.presentation.tracks.TopTracksScreen
 
@@ -23,8 +23,8 @@ fun SpotifyNavigation(
         composable(Screen.TopArtists.route) {
             TopArtistsScreen()
         }
-        composable(Screen.Recommendations.route) {
-            RecommendationsScreen()
+        composable(Screen.NewReleases.route) {
+            NewReleasesScreen()
         }
     }
 } 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/releases/NewReleasesScreen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/releases/NewReleasesScreen.kt
@@ -1,0 +1,127 @@
+package com.daniel.spotyinsights.presentation.releases
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.daniel.spotyinsights.R
+import com.daniel.spotyinsights.presentation.components.ErrorState
+import com.daniel.spotyinsights.presentation.components.ReleaseItem
+import com.daniel.spotyinsights.presentation.components.ReleaseItemSkeleton
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewReleasesScreen(
+    viewModel: NewReleasesViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val pullToRefreshState = rememberPullToRefreshState()
+    val uriHandler = LocalUriHandler.current
+
+    LaunchedEffect(viewModel) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is NewReleasesEffect.ShowError -> {
+                    snackbarHostState.showSnackbar(effect.message)
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(pullToRefreshState.isRefreshing) {
+        if (pullToRefreshState.isRefreshing) {
+            viewModel.setEvent(NewReleasesEvent.Refresh)
+        }
+    }
+
+    LaunchedEffect(state.isRefreshing) {
+        if (!state.isRefreshing) {
+            pullToRefreshState.endRefresh()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.nav_new_releases)) }
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .nestedScroll(pullToRefreshState.nestedScrollConnection)
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                when {
+                    state.error != null && state.releases.isEmpty() -> {
+                        ErrorState(
+                            message = state.error!!,
+                            onRetry = { viewModel.setEvent(NewReleasesEvent.Refresh) }
+                        )
+                    }
+
+                    state.isLoading && state.releases.isEmpty() -> {
+                        LazyVerticalGrid(
+                            columns = GridCells.Fixed(2),
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            items(10) {
+                                ReleaseItemSkeleton()
+                            }
+                        }
+                    }
+
+                    else -> {
+                        LazyVerticalGrid(
+                            columns = GridCells.Fixed(2),
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            items(
+                                items = state.releases,
+                                key = { it.id }
+                            ) { release ->
+                                ReleaseItem(
+                                    release = release,
+                                    onReleaseClick = { clickedRelease ->
+                                        uriHandler.openUri(clickedRelease.spotifyUrl)
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            PullToRefreshContainer(
+                state = pullToRefreshState,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/releases/NewReleasesViewModel.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/releases/NewReleasesViewModel.kt
@@ -1,0 +1,166 @@
+package com.daniel.spotyinsights.presentation.releases
+
+import androidx.lifecycle.viewModelScope
+import com.daniel.spotyinsights.base.BaseViewModel
+import com.daniel.spotyinsights.base.UiEffect
+import com.daniel.spotyinsights.base.UiEvent
+import com.daniel.spotyinsights.base.UiState
+import com.daniel.spotyinsights.domain.model.NewRelease
+import com.daniel.spotyinsights.domain.model.Result
+import com.daniel.spotyinsights.domain.usecase.releases.GetNewReleasesUseCase
+import com.daniel.spotyinsights.domain.usecase.releases.RefreshNewReleasesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class NewReleasesState(
+    val releases: List<NewRelease> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null,
+    val isRefreshing: Boolean = false
+) : UiState
+
+sealed interface NewReleasesEvent : UiEvent {
+    data object Refresh : NewReleasesEvent
+}
+
+sealed interface NewReleasesEffect : UiEffect {
+    data class ShowError(val message: String) : NewReleasesEffect
+}
+
+@HiltViewModel
+class NewReleasesViewModel @Inject constructor(
+    private val getNewReleasesUseCase: GetNewReleasesUseCase,
+    private val refreshNewReleasesUseCase: RefreshNewReleasesUseCase
+) : BaseViewModel<NewReleasesState, NewReleasesEvent, NewReleasesEffect>() {
+
+    private var currentLoadJob: Job? = null
+
+    override fun createInitialState(): NewReleasesState = NewReleasesState()
+
+    init {
+        loadReleases()
+    }
+
+    override fun handleEvent(event: NewReleasesEvent) {
+        when (event) {
+            is NewReleasesEvent.Refresh -> onRefresh()
+        }
+    }
+
+    private fun onRefresh() {
+        viewModelScope.launch {
+            setState { copy(isRefreshing = true) }
+
+            when (val result = refreshNewReleasesUseCase()) {
+                is Result.Success -> {
+                    setState { copy(error = null) }
+                    loadReleases()
+                }
+                is Result.Error -> {
+                    setState {
+                        copy(
+                            error = result.exception.message ?: "Failed to refresh releases",
+                            isRefreshing = false
+                        )
+                    }
+                    setEffect {
+                        NewReleasesEffect.ShowError(
+                            result.exception.message ?: "Failed to refresh releases"
+                        )
+                    }
+                }
+                is Result.Loading -> {
+                    // Loading state is handled by isRefreshing flag
+                }
+            }
+        }
+    }
+
+    private fun loadReleases() {
+        currentLoadJob?.cancel()
+
+        currentLoadJob = viewModelScope.launch {
+            try {
+                getNewReleasesUseCase()
+                    .onEach { result ->
+                        when (result) {
+                            is Result.Success -> {
+                                setState {
+                                    copy(
+                                        releases = result.data,
+                                        isLoading = false,
+                                        error = null,
+                                        isRefreshing = false
+                                    )
+                                }
+                            }
+                            is Result.Error -> {
+                                setState {
+                                    copy(
+                                        error = result.exception.message ?: "Failed to load releases",
+                                        isLoading = false,
+                                        isRefreshing = false
+                                    )
+                                }
+                                setEffect {
+                                    NewReleasesEffect.ShowError(
+                                        result.exception.message ?: "Failed to load releases"
+                                    )
+                                }
+                            }
+                            is Result.Loading -> {
+                                setState {
+                                    copy(
+                                        isLoading = true,
+                                        error = null
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    .catch { throwable ->
+                        if (currentLoadJob?.isCancelled == false) {
+                            setState {
+                                copy(
+                                    error = throwable.message ?: "Unknown error occurred",
+                                    isLoading = false,
+                                    isRefreshing = false
+                                )
+                            }
+                            setEffect {
+                                NewReleasesEffect.ShowError(
+                                    throwable.message ?: "Unknown error occurred"
+                                )
+                            }
+                        }
+                    }
+                    .launchIn(this)
+            } catch (e: Exception) {
+                if (currentLoadJob?.isCancelled == false) {
+                    setState {
+                        copy(
+                            error = e.message ?: "Unknown error occurred",
+                            isLoading = false,
+                            isRefreshing = false
+                        )
+                    }
+                    setEffect {
+                        NewReleasesEffect.ShowError(
+                            e.message ?: "Unknown error occurred"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        currentLoadJob?.cancel()
+    }
+} 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="nav_top_tracks">Top Tracks</string>
     <string name="nav_top_artists">Top Artists</string>
     <string name="nav_recommendations">For You</string>
+    <string name="nav_new_releases">New Releases</string>
 
     <!-- Time Ranges -->
     <string name="time_range_short">4 Weeks</string>

--- a/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
@@ -3,13 +3,17 @@ package com.daniel.spotyinsights.data.di
 import android.content.Context
 import android.util.Log
 import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.daniel.spotyinsights.data.local.SpotifyDatabase
 import com.daniel.spotyinsights.data.local.dao.ArtistDao
 import com.daniel.spotyinsights.data.local.dao.TrackDao
 import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.data.repository.NewReleasesRepositoryImpl
 import com.daniel.spotyinsights.data.repository.RecommendationsRepositoryImpl
 import com.daniel.spotyinsights.data.repository.TopArtistsRepositoryImpl
 import com.daniel.spotyinsights.data.repository.TopTracksRepositoryImpl
+import com.daniel.spotyinsights.domain.repository.NewReleasesRepository
 import com.daniel.spotyinsights.domain.repository.RecommendationsRepository
 import com.daniel.spotyinsights.domain.repository.TopArtistsRepository
 import com.daniel.spotyinsights.domain.repository.TopTracksRepository
@@ -21,8 +25,6 @@ import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import javax.inject.Named
 import javax.inject.Singleton
-import androidx.room.RoomDatabase
-import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -39,23 +41,23 @@ object DataModule {
             SpotifyDatabase::class.java,
             SpotifyDatabase.DATABASE_NAME
         )
-        .addMigrations(
-            SpotifyDatabase.MIGRATION_2_3,
-            SpotifyDatabase.MIGRATION_3_4
-        )
-        .fallbackToDestructiveMigration()
-        .addCallback(object : RoomDatabase.Callback() {
-            override fun onCreate(db: SupportSQLiteDatabase) {
-                super.onCreate(db)
-                Log.d("DataModule", "Database created")
-            }
+            .addMigrations(
+                SpotifyDatabase.MIGRATION_2_3,
+                SpotifyDatabase.MIGRATION_3_4
+            )
+            .fallbackToDestructiveMigration()
+            .addCallback(object : RoomDatabase.Callback() {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    super.onCreate(db)
+                    Log.d("DataModule", "Database created")
+                }
 
-            override fun onOpen(db: SupportSQLiteDatabase) {
-                super.onOpen(db)
-                Log.d("DataModule", "Database opened")
-            }
-        })
-        .build()
+                override fun onOpen(db: SupportSQLiteDatabase) {
+                    super.onOpen(db)
+                    Log.d("DataModule", "Database opened")
+                }
+            })
+            .build()
     }
 
     @Provides
@@ -101,5 +103,13 @@ object DataModule {
         trackDao: TrackDao
     ): RecommendationsRepository {
         return RecommendationsRepositoryImpl(spotifyApiService, trackDao)
+    }
+
+    @Provides
+    @Singleton
+    fun provideNewReleasesRepository(
+        spotifyApiService: SpotifyApiService
+    ): NewReleasesRepository {
+        return NewReleasesRepositoryImpl(spotifyApiService)
     }
 } 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/api/SpotifyApiService.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/api/SpotifyApiService.kt
@@ -1,5 +1,6 @@
 package com.daniel.spotyinsights.data.network.api
 
+import com.daniel.spotyinsights.data.network.model.album.SpotifyNewReleasesResponse
 import com.daniel.spotyinsights.data.network.model.artist.SpotifyArtistResponse
 import com.daniel.spotyinsights.data.network.model.recommendations.SpotifyAvailableGenreSeedsResponse
 import com.daniel.spotyinsights.data.network.model.recommendations.SpotifyRecommendationsResponse
@@ -35,4 +36,11 @@ interface SpotifyApiService {
 
     @GET("recommendations/available-genre-seeds")
     suspend fun getAvailableGenreSeeds(): SpotifyAvailableGenreSeedsResponse
+
+    @GET("browse/new-releases")
+    suspend fun getNewReleases(
+        @Query("country") country: String? = null,
+        @Query("limit") limit: Int = 20,
+        @Query("offset") offset: Int = 0
+    ): SpotifyNewReleasesResponse
 } 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/model/album/SpotifyNewReleasesResponse.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/model/album/SpotifyNewReleasesResponse.kt
@@ -1,0 +1,92 @@
+package com.daniel.spotyinsights.data.network.model.album
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SpotifyNewReleasesResponse(
+    @Json(name = "albums")
+    val albums: SpotifyAlbumsObjectResponse
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyAlbumsObjectResponse(
+    @Json(name = "href")
+    val href: String,
+    @Json(name = "limit")
+    val limit: Int,
+    @Json(name = "next")
+    val next: String?,
+    @Json(name = "offset")
+    val offset: Int,
+    @Json(name = "previous")
+    val previous: String?,
+    @Json(name = "total")
+    val total: Int,
+    @Json(name = "items")
+    val items: List<SpotifyNewReleaseAlbum>
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyNewReleaseAlbum(
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "name")
+    val name: String,
+    @Json(name = "album_type")
+    val albumType: String,
+    @Json(name = "total_tracks")
+    val totalTracks: Int,
+    @Json(name = "available_markets")
+    val availableMarkets: List<String>,
+    @Json(name = "external_urls")
+    val externalUrls: Map<String, String>,
+    @Json(name = "href")
+    val href: String,
+    @Json(name = "images")
+    val images: List<SpotifyImageReleaseResponse>,
+    @Json(name = "release_date")
+    val releaseDate: String,
+    @Json(name = "release_date_precision")
+    val releaseDatePrecision: String,
+    @Json(name = "restrictions")
+    val restrictions: SpotifyAlbumRestrictions?,
+    @Json(name = "type")
+    val type: String,
+    @Json(name = "uri")
+    val uri: String,
+    @Json(name = "artists")
+    val artists: List<SpotifyArtistReleaseResponse>
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyArtistReleaseResponse(
+    @Json(name = "external_urls")
+    val externalUrls: Map<String, String>,
+    @Json(name = "href")
+    val href: String,
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "name")
+    val name: String,
+    @Json(name = "type")
+    val type: String,
+    @Json(name = "uri")
+    val uri: String
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyImageReleaseResponse(
+    @Json(name = "url")
+    val url: String,
+    @Json(name = "height")
+    val height: Int?,
+    @Json(name = "width")
+    val width: Int?
+)
+
+@JsonClass(generateAdapter = true)
+data class SpotifyAlbumRestrictions(
+    @Json(name = "reason")
+    val reason: String
+)

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/NewReleasesRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/NewReleasesRepositoryImpl.kt
@@ -1,0 +1,74 @@
+package com.daniel.spotyinsights.data.repository
+
+import android.util.Log
+import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.domain.model.NewRelease
+import com.daniel.spotyinsights.domain.model.NewReleaseArtist
+import com.daniel.spotyinsights.domain.model.Result
+import com.daniel.spotyinsights.domain.repository.NewReleasesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NewReleasesRepositoryImpl @Inject constructor(
+    private val spotifyApiService: SpotifyApiService
+) : NewReleasesRepository {
+
+    override fun getNewReleases(): Flow<Result<List<NewRelease>>> = flow {
+        emit(Result.Loading)
+        try {
+            val result = refreshNewReleases()
+            when (result) {
+                is Result.Success -> emit(Result.Success(fetchedReleases))
+                is Result.Error -> emit(Result.Error(result.exception))
+                is Result.Loading -> { /* No-op */ }
+            }
+        } catch (e: Exception) {
+            emit(Result.Error(e))
+        }
+    }
+
+    override suspend fun refreshNewReleases(): Result<Unit> {
+        return try {
+            Log.d("NewReleasesRepository", "Refreshing new releases")
+            val response = spotifyApiService.getNewReleases(limit = 50)
+            Log.d("NewReleasesRepository", "API response received. Items count: ${response.albums.items.size}")
+
+            if (response.albums.items.isEmpty()) {
+                Log.w("NewReleasesRepository", "API returned empty new releases list")
+                fetchedReleases = emptyList()
+                return Result.Success(Unit)
+            }
+
+            fetchedReleases = response.albums.items.map { album ->
+                NewRelease(
+                    id = album.id,
+                    name = album.name,
+                    albumType = album.albumType,
+                    totalTracks = album.totalTracks,
+                    artists = album.artists.map { artist ->
+                        NewReleaseArtist(
+                            id = artist.id,
+                            name = artist.name,
+                            spotifyUrl = artist.externalUrls["spotify"] ?: ""
+                        )
+                    },
+                    imageUrl = album.images.firstOrNull()?.url ?: "",
+                    releaseDate = album.releaseDate,
+                    spotifyUrl = album.externalUrls["spotify"] ?: ""
+                )
+            }
+
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Log.e("NewReleasesRepository", "Error refreshing new releases", e)
+            Result.Error(e)
+        }
+    }
+
+    companion object {
+        private var fetchedReleases = emptyList<NewRelease>()
+    }
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/TopArtistsRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/TopArtistsRepositoryImpl.kt
@@ -99,22 +99,22 @@ class TopArtistsRepositoryImpl @Inject constructor(
 
                 // First insert artists and genres
                 artistDao.insertArtists(artists)
-                
+
                 // Insert genres and get their IDs
                 if (genres.isNotEmpty()) {
                     val distinctGenres = genres.distinctBy { it.name }
                     artistDao.insertGenres(distinctGenres)
-                    
+
                     // Query back the inserted genres to get their generated IDs
                     val insertedGenres = artistDao.getGenresByNames(distinctGenres.map { it.name })
-                    
+
                     // Create genre cross-references using the generated IDs
                     val genreCrossRefs = artistGenreCrossRefs.mapNotNull { tempRef ->
                         insertedGenres.find { it.name == tempRef.genreName }?.let { genre ->
                             ArtistGenreCrossRef(artistId = tempRef.artistId, genreId = genre.id)
                         }
                     }
-                    
+
                     if (genreCrossRefs.isNotEmpty()) {
                         artistDao.insertArtistGenreCrossRefs(genreCrossRefs)
                     }

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/model/NewRelease.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/model/NewRelease.kt
@@ -1,0 +1,18 @@
+package com.daniel.spotyinsights.domain.model
+
+data class NewRelease(
+    val id: String,
+    val name: String,
+    val albumType: String,
+    val totalTracks: Int,
+    val artists: List<NewReleaseArtist>,
+    val imageUrl: String,
+    val releaseDate: String,
+    val spotifyUrl: String
+)
+
+data class NewReleaseArtist(
+    val id: String,
+    val name: String,
+    val spotifyUrl: String
+) 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/repository/NewReleasesRepository.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/repository/NewReleasesRepository.kt
@@ -1,0 +1,10 @@
+package com.daniel.spotyinsights.domain.repository
+
+import com.daniel.spotyinsights.domain.model.NewRelease
+import com.daniel.spotyinsights.domain.model.Result
+import kotlinx.coroutines.flow.Flow
+
+interface NewReleasesRepository {
+    fun getNewReleases(): Flow<Result<List<NewRelease>>>
+    suspend fun refreshNewReleases(): Result<Unit>
+} 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/releases/GetNewReleasesUseCase.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/releases/GetNewReleasesUseCase.kt
@@ -1,0 +1,15 @@
+package com.daniel.spotyinsights.domain.usecase.releases
+
+import com.daniel.spotyinsights.domain.model.NewRelease
+import com.daniel.spotyinsights.domain.model.Result
+import com.daniel.spotyinsights.domain.repository.NewReleasesRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetNewReleasesUseCase @Inject constructor(
+    private val repository: NewReleasesRepository
+) {
+    operator fun invoke(): Flow<Result<List<NewRelease>>> {
+        return repository.getNewReleases()
+    }
+} 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/releases/RefreshNewReleasesUseCase.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/usecase/releases/RefreshNewReleasesUseCase.kt
@@ -1,0 +1,13 @@
+package com.daniel.spotyinsights.domain.usecase.releases
+
+import com.daniel.spotyinsights.domain.model.Result
+import com.daniel.spotyinsights.domain.repository.NewReleasesRepository
+import javax.inject.Inject
+
+class RefreshNewReleasesUseCase @Inject constructor(
+    private val repository: NewReleasesRepository
+) {
+    suspend operator fun invoke(): Result<Unit> {
+        return repository.refreshNewReleases()
+    }
+} 


### PR DESCRIPTION
## Description
This PR adds a new feature to display Spotify's new releases in the app. The implementation includes:

### Features
- New releases screen showing latest album releases from Spotify
- Shimmer loading effect for a better user experience
- Pull-to-refresh functionality to update the releases list
- Error handling with retry option
- Direct link to open albums in Spotify

### Technical Implementation
- Added `NewReleasesRepository` interface and implementation
- Created new use cases: `GetNewReleasesUseCase` and `RefreshNewReleasesUseCase`
- Implemented `NewReleasesViewModel` with state management
- Added UI components:
  - `ReleaseItem` for displaying individual releases
  - `ReleaseItemSkeleton` with shimmer effect for loading states
- Integrated with Spotify's New Releases API endpoint
- Added Hilt dependency injection configuration

### Dependencies
- Uses existing Spotify API service
- Utilizes Material 3 components
- Implements Coil for image loading

### Testing
- [ ] Unit tests for repository and use cases
- [ ] UI tests for the new releases screen
- [ ] Manual testing of pull-to-refresh and error states

### Notes
- The feature uses in-memory caching for releases
- Implements proper error handling and loading states
- Follows the existing app architecture pattern

### Changes Made
1. Added repository implementation in `NewReleasesRepositoryImpl`
2. Created view model with state management
3. Implemented UI components with Material 3 design
4. Added Hilt module configuration for dependency injection
5. Integrated with existing Spotify API service

### How to Test
1. Launch the app and navigate to the New Releases screen
2. Verify that releases are loaded and displayed correctly
3. Test pull-to-refresh functionality
4. Check error handling by toggling internet connection
5. Verify that clicking on a release opens it in Spotify