### PR TITLE
Basic Last.fm Integration: Initial API Config, Service, and Repository

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-04-13T06:36:59.635023Z">
+        <DropdownSelection timestamp="2025-05-14T18:28:50.344737Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/danylo.bulavinov/.android/avd/Pixel_4a_API_33.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/danylo.bulavinov/.android/avd/Pixel_4_XL.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -15,6 +15,10 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+
+        val properties = com.android.build.gradle.internal.cxx.configure.gradleLocalProperties(project.rootDir)
+        buildConfigField("String", "LASTFM_API_KEY", "\"${properties.getProperty("LASTFM_API_KEY", "")}\"")
+        buildConfigField("String", "LASTFM_SHARED_SECRET", "\"${properties.getProperty("LASTFM_SHARED_SECRET", "")}\"")
     }
 
     buildTypes {
@@ -25,6 +29,10 @@ android {
                 "proguard-rules.pro"
             )
         }
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     compileOptions {

--- a/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/di/DataModule.kt
@@ -8,19 +8,22 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.daniel.spotyinsights.data.local.SpotifyDatabase
 import com.daniel.spotyinsights.data.local.dao.ArtistDao
 import com.daniel.spotyinsights.data.local.dao.TrackDao
+import com.daniel.spotyinsights.data.network.api.LastFmApiService
 import com.daniel.spotyinsights.data.network.api.SpotifyApiService
+import com.daniel.spotyinsights.data.repository.ArtistRepositoryImpl
+import com.daniel.spotyinsights.data.repository.LastFmRepositoryImpl
 import com.daniel.spotyinsights.data.repository.NewReleasesRepositoryImpl
 import com.daniel.spotyinsights.data.repository.RecommendationsRepositoryImpl
 import com.daniel.spotyinsights.data.repository.TopArtistsRepositoryImpl
 import com.daniel.spotyinsights.data.repository.TopTracksRepositoryImpl
-import com.daniel.spotyinsights.domain.repository.NewReleasesRepository
 import com.daniel.spotyinsights.data.repository.TrackRepositoryImpl
+import com.daniel.spotyinsights.domain.repository.ArtistRepository
+import com.daniel.spotyinsights.domain.repository.LastFmRepository
+import com.daniel.spotyinsights.domain.repository.NewReleasesRepository
 import com.daniel.spotyinsights.domain.repository.RecommendationsRepository
 import com.daniel.spotyinsights.domain.repository.TopArtistsRepository
 import com.daniel.spotyinsights.domain.repository.TopTracksRepository
 import com.daniel.spotyinsights.domain.repository.TrackRepository
-import com.daniel.spotyinsights.data.repository.ArtistRepositoryImpl
-import com.daniel.spotyinsights.domain.repository.ArtistRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -131,5 +134,13 @@ object DataModule {
         spotifyApiService: SpotifyApiService
     ): ArtistRepository {
         return ArtistRepositoryImpl(spotifyApiService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideLastFmRepository(
+        lastFmApiService: LastFmApiService
+    ): LastFmRepository {
+        return LastFmRepositoryImpl(lastFmApiService)
     }
 }

--- a/data/src/main/java/com/daniel/spotyinsights/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/di/NetworkModule.kt
@@ -77,4 +77,22 @@ object NetworkModule {
         .client(okHttpClient)
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
+
+    @Provides
+    @Singleton
+    @Named("lastfm")
+    fun provideLastFmRetrofit(
+        @Named("base") okHttpClient: OkHttpClient,
+        moshi: Moshi
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(com.daniel.spotyinsights.data.network.LastFmApiConfig.BASE_URL)
+        .client(okHttpClient)
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .build()
+
+    @Provides
+    @Singleton
+    fun provideLastFmApiService(@Named("lastfm") retrofit: Retrofit): com.daniel.spotyinsights.data.network.api.LastFmApiService {
+        return retrofit.create(com.daniel.spotyinsights.data.network.api.LastFmApiService::class.java)
+    }
 }

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/LastFmApiConfig.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/LastFmApiConfig.kt
@@ -1,0 +1,9 @@
+package com.daniel.spotyinsights.data.network
+
+import com.daniel.spotyinsights.data.BuildConfig
+
+object LastFmApiConfig {
+    const val BASE_URL = "https://ws.audioscrobbler.com/2.0/"
+    val API_KEY: String get() = BuildConfig.LASTFM_API_KEY
+    val SHARED_SECRET: String get() = BuildConfig.LASTFM_SHARED_SECRET
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/api/LastFmApiService.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/api/LastFmApiService.kt
@@ -1,0 +1,13 @@
+package com.daniel.spotyinsights.data.network.api
+
+import com.daniel.spotyinsights.data.network.model.lastfm.LastFmArtistResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface LastFmApiService {
+    @GET("?method=artist.getinfo&format=json")
+    suspend fun getArtistInfo(
+        @Query("artist") artist: String,
+        @Query("api_key") apiKey: String = com.daniel.spotyinsights.data.network.LastFmApiConfig.API_KEY
+    ): LastFmArtistResponse
+} 

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/model/lastfm/LastFmArtistResponse.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/model/lastfm/LastFmArtistResponse.kt
@@ -1,0 +1,19 @@
+package com.daniel.spotyinsights.data.network.model.lastfm
+
+import com.squareup.moshi.Json
+
+data class LastFmArtistResponse(
+    @Json(name = "artist") val artist: LastFmArtist?
+)
+
+data class LastFmArtist(
+    @Json(name = "name") val name: String?,
+    @Json(name = "mbid") val mbid: String?,
+    @Json(name = "url") val url: String?,
+    @Json(name = "bio") val bio: LastFmArtistBio?
+)
+
+data class LastFmArtistBio(
+    @Json(name = "summary") val summary: String?,
+    @Json(name = "content") val content: String?
+) 

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/LastFmRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/LastFmRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.daniel.spotyinsights.data.repository
+
+import com.daniel.spotyinsights.data.network.api.LastFmApiService
+import com.daniel.spotyinsights.data.network.model.lastfm.LastFmArtist
+import com.daniel.spotyinsights.domain.model.LastFmArtistDomain
+import com.daniel.spotyinsights.domain.repository.LastFmRepository
+import javax.inject.Inject
+
+class LastFmRepositoryImpl @Inject constructor(
+    private val api: LastFmApiService
+) : LastFmRepository {
+    override suspend fun getArtistInfo(artist: String): LastFmArtistDomain? {
+        return api.getArtistInfo(artist).artist.toDomain()
+    }
+}
+
+private fun LastFmArtist?.toDomain(): LastFmArtistDomain? {
+    return this?.let {
+        LastFmArtistDomain(
+            name = it.name,
+        )
+    }
+}

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/TopArtistsRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/TopArtistsRepositoryImpl.kt
@@ -37,16 +37,15 @@ class TopArtistsRepositoryImpl @Inject constructor(
 
     override fun getTopArtists(timeRange: TimeRange): Flow<Result<List<DetailedArtist>>> {
         val minFetchTimeMs = System.currentTimeMillis() - CACHE_DURATION_MS
-        return artistDao.getTopArtists(minFetchTimeMs, timeRange.toApiValue())
-            .map { artists ->
-                if (artists.isEmpty()) {
-                    // If we have no data, return an empty list instead of Loading
-                    // The ViewModel will handle the refresh
-                    Result.Success(emptyList())
-                } else {
-                    Result.Success(artists.map { it.toDomainModel() })
-                }
+        return artistDao.getTopArtists(minFetchTimeMs, timeRange.toApiValue()).map { artists ->
+            if (artists.isEmpty()) {
+                // If we have no data, return an empty list instead of Loading
+                // The ViewModel will handle the refresh
+                Result.Success(emptyList())
+            } else {
+                Result.Success(artists.map { it.toDomainModel() })
             }
+        }
     }
 
     override suspend fun refreshTopArtists(timeRange: TimeRange): Result<Unit> {

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/model/LastFmArtistDomain.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/model/LastFmArtistDomain.kt
@@ -1,0 +1,5 @@
+package com.daniel.spotyinsights.domain.model
+
+data class LastFmArtistDomain(
+    val name: String?,
+)

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/repository/LastFmRepository.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/repository/LastFmRepository.kt
@@ -1,0 +1,8 @@
+package com.daniel.spotyinsights.domain.repository
+
+import com.daniel.spotyinsights.domain.model.LastFmArtistDomain
+
+
+interface LastFmRepository {
+    suspend fun getArtistInfo(artist: String): LastFmArtistDomain?
+} 


### PR DESCRIPTION
This PR introduces the initial groundwork for Last.fm integration:

- Securely loads Last.fm API key and shared secret from local.properties via BuildConfig (analogous to Spotify integration).
- Adds Retrofit service for Last.fm with a sample endpoint (artist.getinfo).
- Adds basic data models for artist info response.
- Implements repository and DI setup for Last.fm.
- No authentication or advanced endpoints yet—this is a minimal, public-data-only foundation.

Ready for further endpoints and user authentication if needed in the future.