### PR TITLE
feat: Add Stats screen with user data charts

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="2.0.0" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-//    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
 }
@@ -44,10 +44,6 @@ android {
 
     buildFeatures {
         compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
     packaging {
@@ -117,4 +113,7 @@ dependencies {
 
     // Palette
     implementation("androidx.palette:palette-ktx:1.0.0")
+
+    // Charts
+    implementation(libs.charts.android)
 }

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/Screen.kt
@@ -1,41 +1,44 @@
 package com.daniel.spotyinsights.presentation.navigation
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.ui.graphics.vector.ImageVector
 import com.daniel.spotyinsights.R
 
 sealed class Screen(
     val route: String,
-    val icon: ImageVector,
+    @DrawableRes val iconRes: Int,
     @StringRes val labelResId: Int
 ) {
     data object TopTracks : Screen(
         route = "top_tracks",
-        icon = Icons.Filled.PlayArrow,
+        iconRes = R.drawable.ic_top_tracks,
         labelResId = R.string.nav_top_tracks
     )
 
     data object TopArtists : Screen(
         route = "top_artists",
-        icon = Icons.Filled.Person,
+        iconRes = R.drawable.ic_top_artists,
         labelResId = R.string.nav_top_artists
     )
 
     data object NewReleases : Screen(
         route = "new_releases",
-        icon = Icons.Filled.Star,
+        iconRes = R.drawable.ic_new_releases,
         labelResId = R.string.nav_new_releases
+    )
+
+    data object Stats : Screen(
+        route = "stats",
+        iconRes = R.drawable.ic_pie_chart,
+        labelResId = R.string.nav_stats
     )
 
     companion object {
         val bottomNavItems = listOf(
             TopTracks,
             TopArtists,
-            NewReleases
+            NewReleases,
+            Stats,
         )
     }
 }

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyBottomNavigation.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyBottomNavigation.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -25,7 +26,7 @@ fun SpotifyBottomNavigation(
             NavigationBarItem(
                 icon = {
                     Icon(
-                        imageVector = screen.icon,
+                        painter = painterResource(id = screen.iconRes),
                         contentDescription = stringResource(id = screen.labelResId)
                     )
                 },

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyNavigation.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/navigation/SpotifyNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.daniel.spotyinsights.presentation.artists.ArtistDetailScreen
 import com.daniel.spotyinsights.presentation.releases.NewReleasesScreen
+import com.daniel.spotyinsights.presentation.stats.StatsScreen
 import com.daniel.spotyinsights.presentation.top_artists.TopArtistsScreen
 import com.daniel.spotyinsights.presentation.tracks.TopTracksScreen
 import com.daniel.spotyinsights.presentation.tracks.TrackDetailScreen
@@ -29,6 +30,9 @@ fun SpotifyNavigation(
         }
         composable(Screen.NewReleases.route) {
             NewReleasesScreen()
+        }
+        composable(Screen.Stats.route) {
+            StatsScreen()
         }
         composable(
             route = "track_detail/{trackId}",

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/releases/NewReleasesScreen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/releases/NewReleasesScreen.kt
@@ -1,6 +1,5 @@
 package com.daniel.spotyinsights.presentation.releases
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -13,15 +12,13 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -51,17 +48,6 @@ fun NewReleasesScreen(
         }
     }
 
-    LaunchedEffect(pullToRefreshState.isRefreshing) {
-        if (pullToRefreshState.isRefreshing) {
-            viewModel.setEvent(NewReleasesEvent.Refresh)
-        }
-    }
-
-    LaunchedEffect(state.isRefreshing) {
-        if (!state.isRefreshing) {
-            pullToRefreshState.endRefresh()
-        }
-    }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -71,11 +57,13 @@ fun NewReleasesScreen(
             )
         }
     ) { paddingValues ->
-        Box(
+        PullToRefreshBox(
+            isRefreshing = state.isRefreshing,
+            state = pullToRefreshState,
+            onRefresh = { viewModel.setEvent(NewReleasesEvent.Refresh) },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .nestedScroll(pullToRefreshState.nestedScrollConnection)
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
                 when {
@@ -117,11 +105,6 @@ fun NewReleasesScreen(
                     }
                 }
             }
-
-            PullToRefreshContainer(
-                state = pullToRefreshState,
-                modifier = Modifier.align(Alignment.TopCenter)
-            )
         }
     }
 } 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/stats/StatsScreen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/stats/StatsScreen.kt
@@ -1,0 +1,102 @@
+package com.daniel.spotyinsights.presentation.stats
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.dautovicharis.charts.LineChart
+import io.github.dautovicharis.charts.PieChart
+import io.github.dautovicharis.charts.model.toChartDataSet
+import io.github.dautovicharis.charts.style.PieChartDefaults
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Composable
+fun StatsScreen(
+    viewModel: StatsViewModel = hiltViewModel()
+) {
+    val tags by viewModel.tags.collectAsStateWithLifecycle()
+    val playCountPerDay by viewModel.playCountPerDay.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadTopTags()
+        viewModel.loadPlayCountPerDay()
+    }
+
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Stats",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+        if (tags.isNotEmpty()) {
+            val dataSet = tags.map { it.count?.toFloat() ?: 0f }
+                .toChartDataSet(
+                    title = "Top Genres in the World",
+                    labels = tags.map { it.name ?: "" }
+                )
+            val pieColors = listOf(
+                Color(0xFF6EC6FF), // Light Blue
+                Color(0xFFFFB74D), // Soft Orange
+                Color(0xFF81C784), // Mint Green
+                Color(0xFFF06292), // Pinkish
+                Color(0xFFBA68C8), // Lavender
+                Color(0xFFFFD54F), // Gold
+                Color(0xFFA1887F), // Taupe
+                Color(0xFF4DB6AC), // Teal
+                Color(0xFFFF8A65), // Coral
+                Color(0xFF9575CD)  // Soft Purple
+            )
+            PieChart(
+                dataSet = dataSet,
+                style = PieChartDefaults.style(
+                    legendVisible = true,
+                    pieColors = pieColors
+                )
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            // Simple line chart for playcount per day with short date and playcount labels
+            val lineData = playCountPerDay.map { it.count.toFloat() }
+            val shortDateFormatter = DateTimeFormatter.ofPattern("d MMM", Locale.getDefault())
+            val lineLabels = playCountPerDay.map {
+                val date = try {
+                    LocalDate.parse(it.date)
+                } catch (e: Exception) {
+                    null
+                }
+                val formattedDate = date?.format(shortDateFormatter) ?: it.date
+                "$formattedDate: ${it.count}"
+            }
+            LineChart(
+                dataSet = lineData.toChartDataSet(
+                    title = "Playcount per Day",
+                    labels = lineLabels
+                ),
+                // You can add style here if needed
+            )
+        } else {
+            CircularProgressIndicator(modifier = Modifier.padding(top = 32.dp))
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/stats/StatsViewModel.kt
@@ -1,0 +1,35 @@
+package com.daniel.spotyinsights.presentation.stats
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daniel.spotyinsights.domain.model.LastFmTagDomain
+import com.daniel.spotyinsights.domain.model.PlayCountPerDay
+import com.daniel.spotyinsights.domain.repository.LastFmRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class StatsViewModel @Inject constructor(
+    private val lastFmRepository: LastFmRepository
+) : ViewModel() {
+    private val _tags = MutableStateFlow<List<LastFmTagDomain>>(emptyList())
+    val tags: StateFlow<List<LastFmTagDomain>> = _tags
+
+    private val _playCountPerDay = MutableStateFlow<List<PlayCountPerDay>>(emptyList())
+    val playCountPerDay: StateFlow<List<PlayCountPerDay>> = _playCountPerDay
+
+    fun loadTopTags() {
+        viewModelScope.launch {
+            _tags.value = lastFmRepository.getTopTags()
+        }
+    }
+
+    fun loadPlayCountPerDay() {
+        viewModelScope.launch {
+            _playCountPerDay.value = lastFmRepository.getPlayCountPerDay("Avertin21")
+        }
+    }
+} 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsScreen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/top_artists/TopArtistsScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,18 +23,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
 import com.daniel.spotyinsights.R
 import com.daniel.spotyinsights.presentation.components.ArtistItem
 import com.daniel.spotyinsights.presentation.components.ArtistItemSkeleton
 import com.daniel.spotyinsights.presentation.components.ErrorState
 import com.daniel.spotyinsights.presentation.components.TimeRangeSelector
-import androidx.navigation.NavController
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,18 +54,6 @@ fun TopArtistsScreen(
         }
     }
 
-    LaunchedEffect(pullToRefreshState.isRefreshing) {
-        if (pullToRefreshState.isRefreshing) {
-            viewModel.setEvent(TopArtistsEvent.Refresh)
-        }
-    }
-
-    LaunchedEffect(state.isLoading) {
-        if (!state.isLoading && pullToRefreshState.isRefreshing) {
-            pullToRefreshState.endRefresh()
-        }
-    }
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -76,11 +62,13 @@ fun TopArtistsScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
-        Box(
+        PullToRefreshBox(
+            isRefreshing = state.isLoading,
+            state = pullToRefreshState,
+            onRefresh = { viewModel.setEvent(TopArtistsEvent.Refresh) },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .nestedScroll(pullToRefreshState.nestedScrollConnection)
         ) {
             Column(
                 modifier = Modifier.fillMaxSize()
@@ -105,6 +93,7 @@ fun TopArtistsScreen(
                             }
                         }
                     }
+
                     state.error != null && state.artists.isEmpty() -> {
                         Box(
                             modifier = Modifier.fillMaxSize(),
@@ -116,6 +105,7 @@ fun TopArtistsScreen(
                             )
                         }
                     }
+
                     else -> {
                         LazyVerticalGrid(
                             columns = GridCells.Fixed(2),
@@ -136,11 +126,6 @@ fun TopArtistsScreen(
                     }
                 }
             }
-
-            PullToRefreshContainer(
-                state = pullToRefreshState,
-                modifier = Modifier.align(Alignment.TopCenter)
-            )
         }
     }
 } 

--- a/app/src/main/java/com/daniel/spotyinsights/presentation/tracks/TopTracksScreen.kt
+++ b/app/src/main/java/com/daniel/spotyinsights/presentation/tracks/TopTracksScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,7 +22,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -54,18 +53,6 @@ fun TopTracksScreen(
         }
     }
 
-    LaunchedEffect(pullToRefreshState.isRefreshing) {
-        if (pullToRefreshState.isRefreshing) {
-            viewModel.setEvent(TopTracksEvent.Refresh)
-        }
-    }
-
-    LaunchedEffect(state.isRefreshing) {
-        if (!state.isRefreshing) {
-            pullToRefreshState.endRefresh()
-        }
-    }
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -74,11 +61,13 @@ fun TopTracksScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
-        Box(
+        PullToRefreshBox(
+            isRefreshing = state.isRefreshing,
+            state = pullToRefreshState,
+            onRefresh = { viewModel.setEvent(TopTracksEvent.Refresh) },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .nestedScroll(pullToRefreshState.nestedScrollConnection)
         ) {
             Column(
                 modifier = Modifier.fillMaxSize()
@@ -134,11 +123,6 @@ fun TopTracksScreen(
                     }
                 }
             }
-
-            PullToRefreshContainer(
-                state = pullToRefreshState,
-                modifier = Modifier.align(Alignment.TopCenter)
-            )
         }
     }
 } 

--- a/app/src/main/res/drawable/ic_new_releases.xml
+++ b/app/src/main/res/drawable/ic_new_releases.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,5h-2V3H7v2H5C3.9,5 3,5.9 3,7v1c0,2.55 1.92,4.63 4.39,4.94c0.63,1.5 1.98,2.63 3.61,2.96V19H7v2h10v-2h-4v-3.1c1.63,-0.33 2.98,-1.46 3.61,-2.96C19.08,12.63 21,10.55 21,8V7C21,5.9 20.1,5 19,5zM5,8V7h2v3.82C5.84,10.4 5,9.3 5,8zM19,8c0,1.3 -0.84,2.4 -2,2.82V7h2V8z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_pie_chart.xml
+++ b/app/src/main/res/drawable/ic_pie_chart.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M11,2v20c-5.07,-0.5 -9,-4.79 -9,-10s3.93,-9.5 9,-10zM13.03,2v8.99L22,10.99c-0.47,-4.74 -4.24,-8.52 -8.97,-8.99zM13.03,13.01L13.03,22c4.74,-0.47 8.5,-4.25 8.97,-8.99h-8.97z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_top_artists.xml
+++ b/app/src/main/res/drawable/ic_top_artists.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_top_tracks.xml
+++ b/app/src/main/res/drawable/ic_top_tracks.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,3v9.28c-0.47,-0.17 -0.97,-0.28 -1.5,-0.28C8.01,12 6,14.01 6,16.5S8.01,21 10.5,21c2.31,0 4.2,-1.75 4.45,-4H15V6h4V3h-7z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="nav_top_artists">Top Artists</string>
     <string name="nav_recommendations">For You</string>
     <string name="nav_new_releases">New Releases</string>
+    <string name="nav_stats">Stats</string>
 
     <!-- Time Ranges -->
     <string name="time_range_short">4 Weeks</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.internal.impldep.junit.runner.Version.id
-
 buildscript {
     repositories {
         google()
@@ -11,7 +9,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
-//    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
 }

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/api/LastFmApiService.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/api/LastFmApiService.kt
@@ -1,6 +1,8 @@
 package com.daniel.spotyinsights.data.network.api
 
 import com.daniel.spotyinsights.data.network.model.lastfm.LastFmArtistResponse
+import com.daniel.spotyinsights.data.network.model.lastfm.LastFmUserTopTagsResponse
+import com.daniel.spotyinsights.data.network.model.lastfm.LastFmRecentTracksResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -10,4 +12,16 @@ interface LastFmApiService {
         @Query("artist") artist: String,
         @Query("api_key") apiKey: String = com.daniel.spotyinsights.data.network.LastFmApiConfig.API_KEY
     ): LastFmArtistResponse
-} 
+
+    @GET("?method=tag.getTopTags&format=json")
+    suspend fun getTopTags(
+        @Query("api_key") apiKey: String = com.daniel.spotyinsights.data.network.LastFmApiConfig.API_KEY,
+    ): LastFmUserTopTagsResponse
+
+    @GET("?method=user.getrecenttracks&format=json")
+    suspend fun getRecentTracks(
+        @Query("user") user: String,
+        @Query("api_key") apiKey: String = com.daniel.spotyinsights.data.network.LastFmApiConfig.API_KEY,
+        @Query("limit") limit: Int = 200
+    ): LastFmRecentTracksResponse
+}

--- a/data/src/main/java/com/daniel/spotyinsights/data/network/model/lastfm/LastFmArtistResponse.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/network/model/lastfm/LastFmArtistResponse.kt
@@ -1,6 +1,7 @@
 package com.daniel.spotyinsights.data.network.model.lastfm
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
 data class LastFmArtistResponse(
     @Json(name = "artist") val artist: LastFmArtist?
@@ -16,4 +17,38 @@ data class LastFmArtist(
 data class LastFmArtistBio(
     @Json(name = "summary") val summary: String?,
     @Json(name = "content") val content: String?
+)
+
+data class LastFmUserTopTagsResponse(
+    @Json(name = "toptags") val toptags: LastFmTopTags?
+)
+
+data class LastFmTopTags(
+    @Json(name = "tag") val tag: List<LastFmTag>?
+)
+
+data class LastFmTag(
+    @Json(name = "name") val name: String?,
+    @Json(name = "count") val count: Int?,
+    @Json(name = "url") val url: String?
+)
+
+@JsonClass(generateAdapter = true)
+data class LastFmRecentTracksResponse(
+    @Json(name = "recenttracks") val recenttracks: LastFmRecentTracks?
+)
+
+@JsonClass(generateAdapter = true)
+data class LastFmRecentTracks(
+    @Json(name = "track") val track: List<LastFmRecentTrack>?
+)
+
+@JsonClass(generateAdapter = true)
+data class LastFmRecentTrack(
+    @Json(name = "date") val date: LastFmRecentTrackDate?
+)
+
+@JsonClass(generateAdapter = true)
+data class LastFmRecentTrackDate(
+    @Json(name = "uts") val uts: String?
 ) 

--- a/data/src/main/java/com/daniel/spotyinsights/data/repository/LastFmRepositoryImpl.kt
+++ b/data/src/main/java/com/daniel/spotyinsights/data/repository/LastFmRepositoryImpl.kt
@@ -3,14 +3,40 @@ package com.daniel.spotyinsights.data.repository
 import com.daniel.spotyinsights.data.network.api.LastFmApiService
 import com.daniel.spotyinsights.data.network.model.lastfm.LastFmArtist
 import com.daniel.spotyinsights.domain.model.LastFmArtistDomain
+import com.daniel.spotyinsights.domain.model.LastFmTagDomain
+import com.daniel.spotyinsights.domain.model.PlayCountPerDay
 import com.daniel.spotyinsights.domain.repository.LastFmRepository
 import javax.inject.Inject
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class LastFmRepositoryImpl @Inject constructor(
     private val api: LastFmApiService
 ) : LastFmRepository {
     override suspend fun getArtistInfo(artist: String): LastFmArtistDomain? {
         return api.getArtistInfo(artist).artist.toDomain()
+    }
+
+    override suspend fun getTopTags(): List<LastFmTagDomain> {
+        return api.getTopTags().toptags?.tag?.take(10)?.map {
+            LastFmTagDomain(
+                name = it.name,
+                count = it.count,
+                url = it.url
+            )
+        } ?: emptyList()
+    }
+
+    override suspend fun getPlayCountPerDay(user: String): List<PlayCountPerDay> {
+        val response = api.getRecentTracks(user)
+        val tracks = response.recenttracks?.track ?: emptyList()
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val grouped = tracks.mapNotNull { it.date?.uts?.toLongOrNull() }
+            .map { Date(it * 1000) }
+            .groupBy { dateFormat.format(it) }
+            .mapValues { it.value.size }
+        return grouped.entries.sortedBy { it.key }.map { PlayCountPerDay(it.key, it.value) }
     }
 }
 

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/model/LastFmArtistDomain.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/model/LastFmArtistDomain.kt
@@ -3,3 +3,14 @@ package com.daniel.spotyinsights.domain.model
 data class LastFmArtistDomain(
     val name: String?,
 )
+
+data class LastFmTagDomain(
+    val name: String?,
+    val count: Int?,
+    val url: String?
+)
+
+data class PlayCountPerDay(
+    val date: String, // e.g. "2024-06-01"
+    val count: Int
+)

--- a/domain/src/main/java/com/daniel/spotyinsights/domain/repository/LastFmRepository.kt
+++ b/domain/src/main/java/com/daniel/spotyinsights/domain/repository/LastFmRepository.kt
@@ -1,8 +1,12 @@
 package com.daniel.spotyinsights.domain.repository
 
 import com.daniel.spotyinsights.domain.model.LastFmArtistDomain
+import com.daniel.spotyinsights.domain.model.LastFmTagDomain
+import com.daniel.spotyinsights.domain.model.PlayCountPerDay
 
 
 interface LastFmRepository {
     suspend fun getArtistInfo(artist: String): LastFmArtistDomain?
+    suspend fun getTopTags(): List<LastFmTagDomain>
+    suspend fun getPlayCountPerDay(user: String): List<PlayCountPerDay>
 } 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,7 @@
 [versions]
 # Kotlin and Build
-kotlin = "1.9.0"
+kotlin = "2.0.0"
 android-gradle = "8.2.2"
-compose-compiler = "1.5.2"
 
 # AndroidX and Compose
 core-ktx = "1.12.0"
@@ -34,7 +33,7 @@ junit = "4.13.2"
 androidx-test-ext = "1.1.5"
 espresso = "3.5.1"
 
-ksp-version = "1.9.0-1.0.13"
+ksp-version = "2.0.0-1.0.21"
 
 [libraries]
 # Kotlin and Android Core
@@ -53,7 +52,7 @@ compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
-compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-material3 = { module = "androidx.compose.material3:material3", version = "1.2.1" }
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 
 # Room
@@ -86,6 +85,8 @@ androidx-test-ext = { module = "androidx.test.ext:junit", version.ref = "android
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4" }
 
+charts-android = { module = "io.github.dautovicharis:charts-android", version = "2.0.0" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }
 android-library = { id = "com.android.library", version.ref = "android-gradle" }
@@ -93,6 +94,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp-version" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version = "2.1.20" }
 
 [bundles]
 compose = [


### PR DESCRIPTION
This pull request adds a new "Stats" screen to the SpotyInsights app.

Key features:
- Integration with Last.fm API to fetch user top tags and recent tracks.
- Displays a pie chart showing the distribution of top 10 global tags.
- Displays a line chart showing playcount per day, with formatted date and count labels.
- Implemented using the dautovicharis/Charts library in Jetpack Compose.
- Includes updates to use the latest Compose Material3 PullToRefreshBox API and ensures UI scrollability.